### PR TITLE
chore: avoid special characters in multiline strings

### DIFF
--- a/pylib/gyp/generator/make.py
+++ b/pylib/gyp/generator/make.py
@@ -740,7 +740,7 @@ class MakefileWriter(object):
                     ext: (
                         """\
 $(obj).$(TOOLSET)/$(TARGET)/%%.o: $(srcdir)/%%%s FORCE_DO_CMD
-	@$(call do_cmd,%s,1)
+\t@$(call do_cmd,%s,1)
 """
                         % (ext, COMPILABLE_EXTENSIONS[ext])
                     )
@@ -753,7 +753,7 @@ $(obj).$(TOOLSET)/$(TARGET)/%%.o: $(srcdir)/%%%s FORCE_DO_CMD
                     ext: (
                         """\
 $(obj).$(TOOLSET)/$(TARGET)/%%.o: $(obj).$(TOOLSET)/%%%s FORCE_DO_CMD
-	@$(call do_cmd,%s,1)
+\t@$(call do_cmd,%s,1)
 """
                         % (ext, COMPILABLE_EXTENSIONS[ext])
                     )
@@ -764,7 +764,7 @@ $(obj).$(TOOLSET)/$(TARGET)/%%.o: $(obj).$(TOOLSET)/%%%s FORCE_DO_CMD
                     ext: (
                         """\
 $(obj).$(TOOLSET)/$(TARGET)/%%.o: $(obj)/%%%s FORCE_DO_CMD
-	@$(call do_cmd,%s,1)
+\t@$(call do_cmd,%s,1)
 """
                         % (ext, COMPILABLE_EXTENSIONS[ext])
                     )

--- a/pylib/gyp/generator/msvs.py
+++ b/pylib/gyp/generator/msvs.py
@@ -184,7 +184,7 @@ def _IsWindowsAbsPath(path):
     """
   On Cygwin systems Python needs a little help determining if a path is an absolute Windows path or not, so that
   it does not treat those as relative, which results in bad paths like:
-  '..\C:\<some path>\some_source_code_file.cc'
+  '..\\C:\\<some path>\\some_source_code_file.cc'
   """
     return path.startswith("c:") or path.startswith("C:")
 


### PR DESCRIPTION
`python -m flake8 . --select E101,W191,W605`