### PR TITLE
test: enable flake8 in CI

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 max-complexity = 10
 max-line-length = 88
-extend-ignore = E203
+extend-ignore = E203,C901,E501

--- a/.github/workflows/Python_tests.yml
+++ b/.github/workflows/Python_tests.yml
@@ -24,11 +24,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements_dev.txt
       - name: Lint with flake8
-        run: |
-          # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --count --exit-zero --statistics
+        run: flake8 . --count --show-source --statistics
       - name: Test with pytest
         run: pytest
       # - name: Run doctests with pytest

--- a/pylib/gyp/generator/make.py
+++ b/pylib/gyp/generator/make.py
@@ -2504,9 +2504,10 @@ def GenerateOutput(target_list, target_dicts, data, params):
         # calculating the Makefile path.
         build_file = os.path.join(depth_rel_path, build_file)
         gyp_targets = [
-            target_dicts[target]["target_name"]
-            for target in target_list
-            if target.startswith(build_file) and target in needed_targets
+            target_dicts[qualified_target]["target_name"]
+            for qualified_target in target_list
+            if qualified_target.startswith(build_file)
+            and qualified_target in needed_targets
         ]
         # Only generate Makefiles for gyp files with targets.
         if not gyp_targets:


### PR DESCRIPTION
Ignored:
- C901 (Function is too complex)
- E501 (Line too long)

They are not fixable with "black" and can be dealt with incrementally.