### PR TITLE
ci: add workflow to test Node.js Windows integration

### DIFF
--- a/.github/workflows/nodejs-windows.yml
+++ b/.github/workflows/nodejs-windows.yml
@@ -1,0 +1,27 @@
+name: Node.js Windows integration
+
+on: [push, pull_request]
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - name: Clone node-gyp
+        uses: actions/checkout@v2
+        with:
+          path: gyp-next
+      - name: Clone nodejs/node
+        uses: actions/checkout@v2
+        with:
+          repository: nodejs/node
+          path: node
+      - name: Install deps
+        run: choco install nasm
+      - name: Replace gyp in Node.js
+        run: |
+          rm -Recurse node/tools/gyp
+          cp -Recurse gyp-next node/tools/gyp
+      - name: Build Node.js
+        run: |
+          cd node
+          ./vcbuild.bat


### PR DESCRIPTION
This is expected to fail because of a bug on Windows