### PR TITLE
solaris: fix copy archive bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+- Fixed a bug on Solaris where copying archives failed.
+
 ## [0.3.0] - 2020-06-06
 
 ### Added

--- a/pylib/gyp/generator/make.py
+++ b/pylib/gyp/generator/make.py
@@ -2362,7 +2362,14 @@ def GenerateOutput(target_list, target_dicts, data, params):
             }
         )
     elif flavor == "solaris":
-        header_params.update({"flock": "./gyp-flock-tool flock", "flock_index": 2})
+        copy_archive_arguments = "-pPRf@"
+        header_params.update(
+            {
+                "copy_archive_args": copy_archive_arguments,
+                "flock": "./gyp-flock-tool flock",
+                "flock_index": 2
+            }
+        )
     elif flavor == "freebsd":
         # Note: OpenBSD has sysutils/flock. lockf seems to be FreeBSD specific.
         header_params.update({"flock": "lockf"})


### PR DESCRIPTION
Fix a bug that occurs while copying archives on solaris, because cp(1)
in solaris doesn't support the -a flag. Instead, this commit replaces
that flag with -pPR@, which should be closest to the intended behavior.

Fixes: https://github.com/nodejs/gyp-next/issues/47