### PR TITLE
.flake8: max-complexity and ignore=C901 are mutually exclusive

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
-max-complexity = 10
-max-line-length = 88
-extend-ignore = E203,C901,E501
+max-complexity = 101
+max-line-length = 180
+extend-ignore = E203  # whitespace before ':' to agree with psf/black


### PR DESCRIPTION
NOTE: max-complexity should be 10, not 101!  I have never seen a complexity level so high.

Also max-line-length and ignore=E501 are mutually exclusive.  max-line-length should be 88, not 180.