### PR TITLE
gyp: add missing extensions to compile_commands_json

### DIFF
--- a/pylib/gyp/generator/compile_commands_json.py
+++ b/pylib/gyp/generator/compile_commands_json.py
@@ -61,8 +61,8 @@ def AddCommandsForTarget(cwd, target, params, per_config_commands):
         defines = ["-D" + s for s in defines]
 
         # TODO(bnoordhuis) Handle generated source files.
-        sources = target.get("sources", [])
-        sources = [s for s in sources if s.endswith(".c") or s.endswith(".cc")]
+        extensions = (".c", ".cc", ".cpp", ".cxx")
+        sources = [s for s in target.get("sources", []) if s.endswith(extensions)]
 
         def resolve(filename):
             return os.path.abspath(os.path.join(cwd, filename))


### PR DESCRIPTION
Extends compile_commands_json generator to consider more file extensions
than just c and cc. This commit adds the cpp and cxx extensiosn to the
list of input source files.