### PR TITLE
win: auto-include marmasm sections for Windows on ARM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Removed
 - The `--no-duplicate-basename-check` option was removed.
+- The `msvs_enable_marmasm` configuration option was removed in favor of
+  auto-inclusion of the "marmasm" sections for Windows on ARM.
 
 ## [0.4.0] - 2020-07-14
 

--- a/pylib/gyp/generator/msvs.py
+++ b/pylib/gyp/generator/msvs.py
@@ -84,7 +84,6 @@ generator_additional_non_configuration_keys = [
     "msvs_enable_winrt",
     "msvs_requires_importlibrary",
     "msvs_enable_winphone",
-    "msvs_enable_marmasm",
     "msvs_application_type_revision",
     "msvs_target_platform_version",
     "msvs_target_platform_minversion",
@@ -3671,6 +3670,7 @@ def _GetMSBuildProjectReferences(project):
 def _GenerateMSBuildProject(project, options, version, generator_flags, spec):
     spec = project.spec
     configurations = spec["configurations"]
+    toolset = spec["toolset"]
     project_dir, project_file_name = os.path.split(project.path)
     gyp.common.EnsureDirExists(project.path)
     # Prepare list of sources and excluded sources.
@@ -3684,6 +3684,7 @@ def _GenerateMSBuildProject(project, options, version, generator_flags, spec):
     rule_dependencies = set()
     extension_to_rule_name = {}
     list_excluded = generator_flags.get("msvs_list_excluded_files", True)
+    platforms = _GetUniquePlatforms(spec)
 
     # Don't generate rules if we are using an external builder like ninja.
     if not spec.get("msvs_external_builder"):
@@ -3726,7 +3727,7 @@ def _GenerateMSBuildProject(project, options, version, generator_flags, spec):
         sources,
         rule_dependencies,
         extension_to_rule_name,
-        _GetUniquePlatforms(spec),
+        platforms,
     )
     missing_sources = _VerifySourcesExist(sources, project_dir)
 
@@ -3779,7 +3780,7 @@ def _GenerateMSBuildProject(project, options, version, generator_flags, spec):
         content += _GetMSBuildLocalProperties(project.msbuild_toolset)
     content += import_cpp_props_section
     content += import_masm_props_section
-    if spec.get("msvs_enable_marmasm"):
+    if "arm64" in platforms and toolset == "target":
         content += import_marmasm_props_section
     content += _GetMSBuildExtensions(props_files_of_rules)
     content += _GetMSBuildPropertySheets(configurations, spec)
@@ -3801,7 +3802,7 @@ def _GenerateMSBuildProject(project, options, version, generator_flags, spec):
     content += _GetMSBuildProjectReferences(project)
     content += import_cpp_targets_section
     content += import_masm_targets_section
-    if spec.get("msvs_enable_marmasm"):
+    if "arm64" in platforms and toolset == "target":
         content += import_marmasm_targets_section
     content += _GetMSBuildExtensionTargets(targets_files_of_rules)
 


### PR DESCRIPTION
This removes the msvs_enable_marmasm configuration option that becomes
unnecessary.

Closes: https://github.com/nodejs/gyp-next/issues/64