### PR TITLE
test(ci): add node-gyp integration workflow

### DIFF
--- a/.github/workflows/node-gyp.yml
+++ b/.github/workflows/node-gyp.yml
@@ -1,0 +1,40 @@
+name: node-gyp integration
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Clone gyp-next
+        uses: actions/checkout@v2
+        with:
+          path: gyp-next
+      - name: Clone nodejs/node-gyp
+        uses: actions/checkout@v2
+        with:
+          repository: nodejs/node-gyp
+          path: node-gyp
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Install dependencies
+        run: |
+          cd node-gyp
+          npm install --no-progress
+      - name: Replace gyp in node-gyp
+        shell: bash
+        run: |
+          rm -rf node-gyp/gyp
+          cp -r gyp-next node-gyp/gyp
+      - name: Run tests
+        run: |
+          cd node-gyp
+          npm test

--- a/.github/workflows/nodejs-windows.yml
+++ b/.github/workflows/nodejs-windows.yml
@@ -6,7 +6,7 @@ jobs:
   build-windows:
     runs-on: windows-latest
     steps:
-      - name: Clone node-gyp
+      - name: Clone gyp-next
         uses: actions/checkout@v2
         with:
           path: gyp-next


### PR DESCRIPTION
This should fail on Windows because https://github.com/nodejs/gyp-next/pull/71 has not landed yet. I'll rebase this afterwards.