### PR TITLE
fix cmake on python 3

### DIFF
--- a/pylib/gyp/generator/cmake.py
+++ b/pylib/gyp/generator/cmake.py
@@ -41,7 +41,7 @@ import gyp.xcode_emulation
 try:
     # maketrans moved to str in python3.
     _maketrans = string.maketrans
-except NameError:
+except (NameError, AttributeError):
     _maketrans = str.maketrans
 
 generator_default_variables = {


### PR DESCRIPTION
Python 3.9 on macOS.
```console
Traceback (most recent call last):
  File "/usr/local/lib/node_modules/node-gyp/gyp/gyp_main.py", line 51, in <module>
    sys.exit(gyp.script_main())
  File "/usr/local/lib/node_modules/node-gyp/gyp/pylib/gyp/__init__.py", line 670, in script_main
    return main(sys.argv[1:])
  File "/usr/local/lib/node_modules/node-gyp/gyp/pylib/gyp/__init__.py", line 662, in main
    return gyp_main(args)
  File "/usr/local/lib/node_modules/node-gyp/gyp/pylib/gyp/__init__.py", line 629, in gyp_main
    [generator, flat_list, targets, data] = Load(
  File "/usr/local/lib/node_modules/node-gyp/gyp/pylib/gyp/__init__.py", line 110, in Load
    generator = __import__(generator_name, globals(), locals(), generator_name)
  File "/usr/local/lib/node_modules/node-gyp/gyp/pylib/gyp/generator/cmake.py", line 43, in <module>
    _maketrans = string.maketrans
AttributeError: module 'string' has no attribute 'maketrans'
```