### PR TITLE
Fix ValueError: invalid mode: 'rU' while trying to load binding.gyp

### DIFF
--- a/pylib/gyp/input.py
+++ b/pylib/gyp/input.py
@@ -231,7 +231,7 @@ def LoadOneBuildFile(build_file_path, data, aux_data, includes, is_target, check
         # Open the build file for read ('r') with universal-newlines mode ('U')
         # to make sure platform specific newlines ('\r\n' or '\r') are converted to '\n'
         # which otherwise will fail eval()
-        if sys.platform == "zos":
+        if PY3 or sys.platform == "zos":
             # On z/OS, universal-newlines mode treats the file as an ascii file.
             # But since node-gyp produces ebcdic files, do not use that mode.
             build_file_contents = open(build_file_path, "r").read()


### PR DESCRIPTION
Fixes nodejs/node-gyp#2219 @Brice1994 

File mode `U` is deprecated in Python 3 https://docs.python.org/3/library/functions.html#open

Would be auto-fixed by https://github.com/asottile/pyupgrade#redundant-open-modes