### PR TITLE
fix(msvs): do not fix paths in action command arguments

### DIFF
--- a/pylib/gyp/generator/msvs.py
+++ b/pylib/gyp/generator/msvs.py
@@ -423,13 +423,7 @@ def _BuildCommandLineForRuleRaw(
         # file out of the raw command string, and some commands (like python) are
         # actually batch files themselves.
         command.insert(0, "call")
-        # Fix the paths
-        # TODO(quote): This is a really ugly heuristic, and will miss path fixing
-        #              for arguments like "--arg=path" or "/opt:path".
-        # If the argument starts with a slash or dash, it's probably a command line
-        # switch
-        arguments = [i if (i[:1] in "/-") else _FixPath(i) for i in cmd[1:]]
-        arguments = [i.replace("$(InputDir)", "%INPUTDIR%") for i in arguments]
+        arguments = [i.replace("$(InputDir)", "%INPUTDIR%") for i in cmd[1:]]
         arguments = [MSVSSettings.FixVCMacroSlashes(i) for i in arguments]
         if quote_cmd:
             # Support a mode for using cmd directly.


### PR DESCRIPTION
BREAKING CHANGE: On Windows, arguments passed to the "action" commands are no longer transformed to replace slashes with backslashes.