### PR TITLE
gyp: update gyp.el to change case to cl-case

### DIFF
--- a/tools/emacs/gyp-tests.el
+++ b/tools/emacs/gyp-tests.el
@@ -30,7 +30,7 @@
   "For the purposes of face comparison, we're not interested in the
    differences between certain faces. For example, the difference between
    font-lock-comment-delimiter and font-lock-comment-face."
-  (case face
+  (cl-case face
     ((font-lock-comment-delimiter-face) font-lock-comment-face)
     (t face)))
 

--- a/tools/emacs/gyp.el
+++ b/tools/emacs/gyp.el
@@ -213,7 +213,7 @@
                 string-start)
       (setq string-start (gyp-parse-to limit))
       (if string-start
-          (setq group (case (gyp-section-at-point)
+          (setq group (cl-case (gyp-section-at-point)
                         ('dependencies 1)
                         ('variables 2)
                         ('conditions 2)


### PR DESCRIPTION
> https://github.com/nodejs/node-gyp/pull/2306

‘case’ is an obsolete alias (as of 27.1); use ‘cl-case’ instead.