### PR TITLE
gyp: update shebang lines from python to python3

### DIFF
--- a/gyp_main.py
+++ b/gyp_main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2009 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be

--- a/pylib/gyp/MSVSSettings_test.py
+++ b/pylib/gyp/MSVSSettings_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2012 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be

--- a/pylib/gyp/__init__.py
+++ b/pylib/gyp/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2012 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be

--- a/pylib/gyp/common_test.py
+++ b/pylib/gyp/common_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2012 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be

--- a/pylib/gyp/easy_xml_test.py
+++ b/pylib/gyp/easy_xml_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2011 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be

--- a/pylib/gyp/flock_tool.py
+++ b/pylib/gyp/flock_tool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2011 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.

--- a/pylib/gyp/generator/msvs_test.py
+++ b/pylib/gyp/generator/msvs_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2012 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.

--- a/pylib/gyp/generator/ninja_test.py
+++ b/pylib/gyp/generator/ninja_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2012 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be

--- a/pylib/gyp/generator/xcode_test.py
+++ b/pylib/gyp/generator/xcode_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2013 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be

--- a/pylib/gyp/input_test.py
+++ b/pylib/gyp/input_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2013 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be

--- a/pylib/gyp/mac_tool.py
+++ b/pylib/gyp/mac_tool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2012 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.

--- a/pylib/gyp/win_tool.py
+++ b/pylib/gyp/win_tool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2012 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2009 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be

--- a/test_gyp.py
+++ b/test_gyp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2012 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.

--- a/tools/graphviz.py
+++ b/tools/graphviz.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2011 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be

--- a/tools/pretty_gyp.py
+++ b/tools/pretty_gyp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2012 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be

--- a/tools/pretty_sln.py
+++ b/tools/pretty_sln.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2012 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be

--- a/tools/pretty_vcproj.py
+++ b/tools/pretty_vcproj.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2012 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be


### PR DESCRIPTION
Fedora's `.rpm` package builder errors out upon encountering "ambiguous" `python` shebangs. Now that Python 2 support is dropped from `gyp-next`, it shouldn't hurt to switch these to `python3`.

See conversation at https://github.com/nodejs/node-gyp/pull/2300#issuecomment-778601011 for more details of why I'm opening this Pull Request.

See also Fedora's policy about this: https://fedoraproject.org/wiki/Changes/Make_ambiguous_python_shebangs_error

Thanks.