### PR TITLE
gyp: use LDFLAGS_host for host toolset

### DIFF
--- a/pylib/gyp/generator/make.py
+++ b/pylib/gyp/generator/make.py
@@ -319,7 +319,7 @@ CFLAGS.host ?= $(CPPFLAGS_host) $(CFLAGS_host)
 CXX.host ?= %(CXX.host)s
 CXXFLAGS.host ?= $(CPPFLAGS_host) $(CXXFLAGS_host)
 LINK.host ?= %(LINK.host)s
-LDFLAGS.host ?=
+LDFLAGS.host ?= $(LDFLAGS_host)
 AR.host ?= %(AR.host)s
 
 # Define a dir function that can handle spaces.

--- a/pylib/gyp/generator/ninja.py
+++ b/pylib/gyp/generator/ninja.py
@@ -1417,7 +1417,11 @@ class NinjaWriter:
         is_executable = spec["type"] == "executable"
         # The ldflags config key is not used on mac or win. On those platforms
         # linker flags are set via xcode_settings and msvs_settings, respectively.
-        env_ldflags = os.environ.get("LDFLAGS", "").split()
+        if self.toolset == "target":
+            env_ldflags = os.environ.get("LDFLAGS", "").split()
+        elif self.toolset == "host":
+            env_ldflags = os.environ.get("LDFLAGS_host", "").split()
+
         if self.flavor == "mac":
             ldflags = self.xcode_settings.GetLdflags(
                 config_name,


### PR DESCRIPTION
This makes the behaviour similar to that of CFLAGS_host