### PR TITLE
fix: add support of utf8 encoding

### DIFF
--- a/pylib/gyp/easy_xml.py
+++ b/pylib/gyp/easy_xml.py
@@ -2,6 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+import sys
 import re
 import os
 import locale
@@ -121,7 +122,10 @@ def WriteXmlIfChanged(content, path, encoding="utf-8", pretty=False, win32=False
 
     default_encoding = locale.getdefaultlocale()[1]
     if default_encoding and default_encoding.upper() != encoding.upper():
-        xml_string = xml_string.encode(encoding)
+        if sys.platform == "win32" and sys.version_info < (3, 7):
+            xml_string = xml_string.decode("cp1251").encode(encoding)
+        else:
+            xml_string = xml_string.encode(encoding)
 
     # Get the old content
     try:

--- a/pylib/gyp/easy_xml.py
+++ b/pylib/gyp/easy_xml.py
@@ -107,7 +107,8 @@ def _ConstructContentList(xml_parts, specification, pretty, level=0):
         xml_parts.append("/>%s" % new_line)
 
 
-def WriteXmlIfChanged(content, path, encoding="utf-8", pretty=False, win32=(sys.platform == "win32")):
+def WriteXmlIfChanged(content, path, encoding="utf-8", pretty=False,
+                      win32=(sys.platform == "win32")):
     """ Writes the XML content to disk, touching the file only if it has changed.
 
   Args:

--- a/pylib/gyp/easy_xml.py
+++ b/pylib/gyp/easy_xml.py
@@ -107,7 +107,7 @@ def _ConstructContentList(xml_parts, specification, pretty, level=0):
         xml_parts.append("/>%s" % new_line)
 
 
-def WriteXmlIfChanged(content, path, encoding="utf-8", pretty=False, win32=False):
+def WriteXmlIfChanged(content, path, encoding="utf-8", pretty=False, win32=(sys.platform == "win32")):
     """ Writes the XML content to disk, touching the file only if it has changed.
 
   Args:
@@ -122,7 +122,7 @@ def WriteXmlIfChanged(content, path, encoding="utf-8", pretty=False, win32=False
 
     default_encoding = locale.getdefaultlocale()[1]
     if default_encoding and default_encoding.upper() != encoding.upper():
-        if sys.platform == "win32" and sys.version_info < (3, 7):
+        if win32 and sys.version_info < (3, 7):
             xml_string = xml_string.decode("cp1251").encode(encoding)
         else:
             xml_string = xml_string.encode(encoding)

--- a/pylib/gyp/input.py
+++ b/pylib/gyp/input.py
@@ -225,7 +225,7 @@ def LoadOneBuildFile(build_file_path, data, aux_data, includes, is_target, check
         return data[build_file_path]
 
     if os.path.exists(build_file_path):
-        build_file_contents = open(build_file_path).read()
+        build_file_contents = open(build_file_path, encoding='utf-8').read()
     else:
         raise GypError(f"{build_file_path} not found (cwd: {os.getcwd()})")
 


### PR DESCRIPTION
this fix is needed for node-gyp/lib/find-python.js to
work properly with paths, which contain non-ASCII chars

see https://github.com/nodejs/node-gyp/pull/2254 for more info