### PR TITLE
fix: build failure with ninja and Python 3 on Windows 

### DIFF
--- a/pylib/gyp/generator/ninja.py
+++ b/pylib/gyp/generator/ninja.py
@@ -2389,7 +2389,6 @@ def GenerateOutputForConfig(target_list, target_dicts, data, params, config_name
         )
         if flavor == "win":
             master_ninja.variable("ld_host", ld_host)
-            master_ninja.variable("ldxx_host", ldxx_host)
         else:
             master_ninja.variable(
                 "ld_host", CommandWithWrapper("LINK", wrappers, ld_host)

--- a/pylib/gyp/msvs_emulation.py
+++ b/pylib/gyp/msvs_emulation.py
@@ -333,7 +333,7 @@ class MsvsSettings:
         # first level is globally for the configuration (this is what we consider
         # "the" config at the gyp level, which will be something like 'Debug' or
         # 'Release'), VS2015 and later only use this level
-        if self.vs_version.short_name >= 2015:
+        if int(self.vs_version.short_name) >= 2015:
             return config
         # and a second target-specific configuration, which is an
         # override for the global one. |config| is remapped here to take into
@@ -537,7 +537,7 @@ class MsvsSettings:
                 )
             ]
         )
-        if self.vs_version.project_version >= 12.0:
+        if float(self.vs_version.project_version) >= 12.0:
             # New flag introduced in VS2013 (project version 12.0) Forces writes to
             # the program database (PDB) to be serialized through MSPDBSRV.EXE.
             # https://msdn.microsoft.com/en-us/library/dn502518.aspx

--- a/pylib/gyp/win_tool.py
+++ b/pylib/gyp/win_tool.py
@@ -221,8 +221,9 @@ class WinTool:
             # and sometimes doesn't unfortunately.
             with open(our_manifest) as our_f:
                 with open(assert_manifest) as assert_f:
-                    our_data = our_f.read().translate(None, string.whitespace)
-                    assert_data = assert_f.read().translate(None, string.whitespace)
+                    translator = str.maketrans('', '', string.whitespace)
+                    our_data = our_f.read().translate(translator)
+                    assert_data = assert_f.read().translate(translator)
             if our_data != assert_data:
                 os.unlink(out)
 


### PR DESCRIPTION
There are a few python code not updated to support python 3, the code path seems to only run when using ninja on Windows.