### PR TITLE
fix: .S is an extension for asm file on Windows

### DIFF
--- a/pylib/gyp/generator/ninja.py
+++ b/pylib/gyp/generator/ninja.py
@@ -1221,7 +1221,7 @@ class NinjaWriter:
                 command = "cc_s"
             elif (
                 self.flavor == "win"
-                and ext == "asm"
+                and ext in ("asm", "S")
                 and not self.msvs_settings.HasExplicitAsmRules(spec)
             ):
                 command = "asm"


### PR DESCRIPTION
OpenSSL use `.S` extension for asm files and the ninja generator does not recognize it on Windows.