### PR TITLE
Fixed sorting of ProjectRefs when generating project files for xcode.

### DIFF
--- a/pylib/gyp/xcodeproj_file.py
+++ b/pylib/gyp/xcodeproj_file.py
@@ -2990,7 +2990,7 @@ class PBXProject(XCContainerPortal):
             # Xcode seems to sort this list case-insensitively
             self._properties["projectReferences"] = sorted(
                 self._properties["projectReferences"],
-                key=lambda x: x["ProjectRef"].Name().lower
+                key=lambda x: x["ProjectRef"].Name().lower()
             )
         else:
             # The link already exists.  Pull out the relevnt data.


### PR DESCRIPTION
Closes nodejs/node-gyp@2675

Hello. @targos @cclauss @gengjiawen 
I'm trying to generate project files for Breakpad with python 3 on macOS, so I'm switched from gyp to gyp-next.
Unfortunately, the generation fails with the following error.
<details><summary><b>Traceback</b></summary>

```
Traceback (most recent call last):
  File "breakpad/src/build/gyp_breakpad", line 67, in <module>
    main()
  File "breakpad/src/build/gyp_breakpad", line 63, in main
    run_gyp(args)
  File "breakpad/src/build/gyp_breakpad", line 42, in run_gyp
    rc = gyp.main(args)
  File "/usr/local/lib/python3.9/site-packages/gyp/__init__.py", line 654, in main
    return gyp_main(args)
  File "/usr/local/lib/python3.9/site-packages/gyp/__init__.py", line 639, in gyp_main
    generator.GenerateOutput(flat_list, targets, data, params)
  File "/usr/local/lib/python3.9/site-packages/gyp/generator/xcode.py", line 1336, in GenerateOutput
    xct.AddDependency(xcode_targets[dependency])
  File "/usr/local/lib/python3.9/site-packages/gyp/xcodeproj_file.py", line 2690, in AddDependency
    XCTarget.AddDependency(self, other)
  File "/usr/local/lib/python3.9/site-packages/gyp/xcodeproj_file.py", line 2389, in AddDependency
    other_project_ref = pbxproject.AddOrGetProjectReference(other_pbxproject)[1]
  File "/usr/local/lib/python3.9/site-packages/gyp/xcodeproj_file.py", line 2992, in AddOrGetProjectReference
    self._properties["projectReferences"] = sorted(
TypeError: '<' not supported between instances of 'builtin_function_or_method' and 'builtin_function_or_method'
```
</details>

So this small PR fixes that problem.
It would be really nice if merging didn't take too long.
