### PR TITLE
fix(make): only generate makefile for multiple toolsets if requested

### DIFF
--- a/pylib/gyp/generator/make.py
+++ b/pylib/gyp/generator/make.py
@@ -50,7 +50,7 @@ generator_default_variables = {
 }
 
 # Make supports multiple toolsets
-generator_supports_multiple_toolsets = True
+generator_supports_multiple_toolsets = gyp.common.CrossCompileRequested()
 
 # Request sorted dependencies in the order from dependents to dependencies.
 generator_wants_sorted_dependencies = False


### PR DESCRIPTION
It's already like this in the msvs and ninja generators.

Refs: https://github.com/nodejs/node/pull/40934