### PR TITLE
feat: Add proper support for IBM i

### DIFF
--- a/pylib/gyp/common.py
+++ b/pylib/gyp/common.py
@@ -454,6 +454,8 @@ def GetFlavor(params):
         return "aix"
     if sys.platform.startswith(("os390", "zos")):
         return "zos"
+    if sys.platform == "os400":
+        return "os400"
 
     return "linux"
 
@@ -463,9 +465,13 @@ def CopyTool(flavor, out_path, generator_flags={}):
   to |out_path|."""
     # aix and solaris just need flock emulation. mac and win use more complicated
     # support scripts.
-    prefix = {"aix": "flock", "solaris": "flock", "mac": "mac", "win": "win"}.get(
-        flavor, None
-    )
+    prefix = {
+        "aix": "flock",
+        "os400": "flock",
+        "solaris": "flock",
+        "mac": "mac",
+        "win": "win",
+    }.get(flavor, None)
     if not prefix:
         return
 

--- a/pylib/gyp/flock_tool.py
+++ b/pylib/gyp/flock_tool.py
@@ -41,7 +41,7 @@ class FlockTool:
         # with EBADF, that's why we use this F_SETLK
         # hack instead.
         fd = os.open(lockfile, os.O_WRONLY | os.O_NOCTTY | os.O_CREAT, 0o666)
-        if sys.platform.startswith("aix"):
+        if sys.platform.startswith("aix") or sys.platform == "os400":
             # Python on AIX is compiled with LARGEFILE support, which changes the
             # struct size.
             op = struct.pack("hhIllqq", fcntl.F_WRLCK, 0, 0, 0, 0, 0, 0)

--- a/pylib/gyp/generator/make.py
+++ b/pylib/gyp/generator/make.py
@@ -237,6 +237,24 @@ cmd_solink_module = $(LINK.$(TOOLSET)) -shared $(GYP_LDFLAGS) $(LDFLAGS.$(TOOLSE
 """  # noqa: E501
 
 
+LINK_COMMANDS_OS400 = """\
+quiet_cmd_alink = AR($(TOOLSET)) $@
+cmd_alink = rm -f $@ && $(AR.$(TOOLSET)) -X64 crs $@ $(filter %.o,$^)
+
+quiet_cmd_alink_thin = AR($(TOOLSET)) $@
+cmd_alink_thin = rm -f $@ && $(AR.$(TOOLSET)) -X64 crs $@ $(filter %.o,$^)
+
+quiet_cmd_link = LINK($(TOOLSET)) $@
+cmd_link = $(LINK.$(TOOLSET)) $(GYP_LDFLAGS) $(LDFLAGS.$(TOOLSET)) -o $@ $(LD_INPUTS) $(LIBS)
+
+quiet_cmd_solink = SOLINK($(TOOLSET)) $@
+cmd_solink = $(LINK.$(TOOLSET)) -shared $(GYP_LDFLAGS) $(LDFLAGS.$(TOOLSET)) -o $@ $(LD_INPUTS) $(LIBS)
+
+quiet_cmd_solink_module = SOLINK_MODULE($(TOOLSET)) $@
+cmd_solink_module = $(LINK.$(TOOLSET)) -shared $(GYP_LDFLAGS) $(LDFLAGS.$(TOOLSET)) -o $@ $(filter-out FORCE_DO_CMD, $^) $(LIBS)
+"""  # noqa: E501
+
+
 LINK_COMMANDS_OS390 = """\
 quiet_cmd_alink = AR($(TOOLSET)) $@
 cmd_alink = rm -f $@ && $(AR.$(TOOLSET)) crs $@ $(filter %.o,$^)
@@ -2347,6 +2365,16 @@ def GenerateOutput(target_list, target_dicts, data, params):
             {
                 "copy_archive_args": copy_archive_arguments,
                 "link_commands": LINK_COMMANDS_AIX,
+                "flock": "./gyp-flock-tool flock",
+                "flock_index": 2,
+            }
+        )
+    elif flavor == "os400":
+        copy_archive_arguments = "-pPRf"
+        header_params.update(
+            {
+                "copy_archive_args": copy_archive_arguments,
+                "link_commands": LINK_COMMANDS_OS400,
                 "flock": "./gyp-flock-tool flock",
                 "flock_index": 2,
             }

--- a/test_gyp.py
+++ b/test_gyp.py
@@ -116,6 +116,7 @@ def main(argv=None):
     else:
         format_list = {
             "aix5": ["make"],
+            "os400": ["make"],
             "freebsd7": ["make"],
             "freebsd8": ["make"],
             "openbsd5": ["make"],


### PR DESCRIPTION
Python 3.9 on IBM i now properly returns "os400" for sys.platform
instead of claiming to be AIX as it did previously. While the IBM i PASE
environment is compatible with AIX, it is a subset and has numerous
differences which makes it beneficial to distinguish, however this means
that it now needs explicit support here.