### PR TITLE
chore: add npm support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,5 @@ cython_debug/
 # static files generated from Django application using `collectstatic`
 media
 static
+
+node_modules

--- a/npmlib/bin/gyp.js
+++ b/npmlib/bin/gyp.js
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+'use strict';
+
+const { execFileSync } = require('child_process');
+const path = require('path');
+
+const { detect } = require('detect-python-interpreter');
+
+const python = detect();
+
+const args = process.argv.slice(2);
+args.unshift(path.join(__dirname, '..', '..', 'gyp_main.py'));
+
+try {
+  execFileSync(python, args, {
+    stdio: 'inherit',
+  });
+} catch (e) {
+  process.exit(e.status || 9);
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "gyp-next",
+  "version": "0.12.1",
+  "description": "A fork of the GYP build system for use in the Node.js projects",
+  "main": "index.js",
+  "scripts": {
+    "postinstall": "rm -f package-lock.json"
+  },
+  "bin": {
+    "gyp": "npmlib/bin/gyp.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nodejs/gyp-next.git"
+  },
+  "keywords": [
+    "gyp-next"
+  ],
+  "author": "PLACEHOLDER",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/nodejs/gyp-next/issues"
+  },
+  "homepage": "https://github.com/nodejs/gyp-next#readme",
+  "dependencies": {
+    "detect-python-interpreter": "^1.0.0"
+  }
+}


### PR DESCRIPTION
Someday we may import gyp-next as an npm package. just like clang-format. Even, we can replace this in node repo.