### PR TITLE
fix: update with changes for OpenSSL 3.x

### DIFF
--- a/pylib/gyp/__init__.py
+++ b/pylib/gyp/__init__.py
@@ -103,6 +103,14 @@ def Load(
     for (key, val) in generator.generator_default_variables.items():
         default_variables.setdefault(key, val)
 
+    output_dir = params["options"].generator_output or params["options"].toplevel_dir
+    if (default_variables['GENERATOR'] == 'ninja'):
+      default_variables.setdefault("PRODUCT_DIR_ABS", os.path.join(output_dir,
+          'out', default_variables['build_type']))
+    else:
+      default_variables.setdefault("PRODUCT_DIR_ABS", os.path.join(output_dir,
+          default_variables['build_type']))
+
     # Give the generator the opportunity to set additional variables based on
     # the params it will receive in the output phase.
     if getattr(generator, "CalculateVariables", None):

--- a/pylib/gyp/__init__.py
+++ b/pylib/gyp/__init__.py
@@ -105,11 +105,11 @@ def Load(
 
     output_dir = params["options"].generator_output or params["options"].toplevel_dir
     if (default_variables['GENERATOR'] == 'ninja'):
-      default_variables.setdefault("PRODUCT_DIR_ABS", os.path.join(output_dir,
-          'out', default_variables['build_type']))
+        default_variables.setdefault("PRODUCT_DIR_ABS", os.path.join(output_dir,
+                                     'out', default_variables['build_type']))
     else:
-      default_variables.setdefault("PRODUCT_DIR_ABS", os.path.join(output_dir,
-          default_variables['build_type']))
+        default_variables.setdefault("PRODUCT_DIR_ABS", os.path.join(output_dir,
+                                     default_variables['build_type']))
 
     # Give the generator the opportunity to set additional variables based on
     # the params it will receive in the output phase.

--- a/pylib/gyp/__init__.py
+++ b/pylib/gyp/__init__.py
@@ -104,7 +104,7 @@ def Load(
         default_variables.setdefault(key, val)
 
     output_dir = params["options"].generator_output or params["options"].toplevel_dir
-    if (default_variables['GENERATOR'] == 'ninja'):
+    if default_variables['GENERATOR'] == 'ninja':
         default_variables.setdefault("PRODUCT_DIR_ABS", os.path.join(output_dir,
                                      'out', default_variables['build_type']))
     else:

--- a/pylib/gyp/__init__.py
+++ b/pylib/gyp/__init__.py
@@ -105,11 +105,10 @@ def Load(
 
     output_dir = params["options"].generator_output or params["options"].toplevel_dir
     if default_variables['GENERATOR'] == 'ninja':
-        default_variables.setdefault("PRODUCT_DIR_ABS", os.path.join(output_dir,
-                                     'out', default_variables['build_type']))
+        prod_dir = os.path.join(output_dir, 'out', default_variables['build_type'])
     else:
-        default_variables.setdefault("PRODUCT_DIR_ABS", os.path.join(output_dir,
-                                     default_variables['build_type']))
+        prod_dir = os.path.join(output_dir, default_variables['build_type'])
+    default_variables.setdefault("PRODUCT_DIR_ABS", prod_dir)
 
     # Give the generator the opportunity to set additional variables based on
     # the params it will receive in the output phase.


### PR DESCRIPTION
This commit updates __init__.py with changes that were made directly
in Node.js (sorry about this but at the time I was not aware that there
this upstream repo existed).

It includes changes from two commits in Node.js:
 Commit f4bd91b0e2d7f07365ccf6bba943ba97d6f95cc9 ("deps,build,
tools: fix openssl-is-fips for ninja builds) and
Commit 66da32c045035cf2710a48773dc6f55f00e20c40 ("deps,test,src,doc,
tools: update to OpenSSL 3.0")

Refs: https://github.com/nodejs/node/issues/40735