### PR TITLE
chore: Check compatibility with Python 3.11 release candidate 1

### DIFF
--- a/.github/workflows/Python_tests.yml
+++ b/.github/workflows/Python_tests.yml
@@ -2,7 +2,12 @@
 # TODO: Enable pytest --doctest-modules
 
 name: Python_tests
-on: [push, pull_request]
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
 jobs:
   Python_tests:
     runs-on: ${{ matrix.os }}
@@ -11,11 +16,11 @@ jobs:
       max-parallel: 8
       matrix:
         os: [macos-latest, ubuntu-latest] # , windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/node-gyp.yml
+++ b/.github/workflows/node-gyp.yml
@@ -1,9 +1,12 @@
 name: node-gyp integration
-
-on: [push, pull_request]
-
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
 jobs:
-  test:
+  integration:
     strategy:
       fail-fast: false
       matrix:
@@ -24,7 +27,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 14.x
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
       - name: Install dependencies

--- a/.github/workflows/nodejs-windows.yml
+++ b/.github/workflows/nodejs-windows.yml
@@ -1,6 +1,11 @@
 name: Node.js Windows integration
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
 
 jobs:
   build-windows:


### PR DESCRIPTION
https://www.python.org/download/pre-releases
> Python 3.11 is up to 10-60% faster than Python 3.10

To ensure that tests are run on `pull_request` or `pull` but ***not both***, we use:
```
on:
  push:
    branches: [ main ]
  pull_request:
    branches: [ main ]
  workflow_dispatch:
```
The `workflow_dispatch` allows repo maintainers to run the tests on-demand.