### PR TITLE
fix(msvs): don't preprocess marmasm sources on vs2022+

### DIFF
--- a/pylib/gyp/generator/msvs.py
+++ b/pylib/gyp/generator/msvs.py
@@ -3633,6 +3633,15 @@ def _AddSources2(
                     elif file_name.startswith("$("):
                         file_name = re.sub(r"^\$\([^)]+\)\\", "", file_name)
                     detail.append(["ObjectFileName", "$(IntDir)\\" + file_name])
+                if element == "MARMASM":
+                    # When compiling on VS2022+, compilation fails with a C1083 as
+                    # MARMASM tries to preprocess by default.
+                    # https://developercommunity.visualstudio.com/t/ARM64---fatal-error-C1083:-Cannot-open/10119540
+                    detail.append([
+                        "PreprocessWithCl",
+                        {"Condition": "'$(VisualStudioVersion)' >= '17.0'"},
+                        "false"
+                    ])
                 grouped_sources[group].append([element, {"Include": source}] + detail)
 
 


### PR DESCRIPTION
When compiling on VS2022+, compilation fails with a C1083 as MARMASM tries to preprocess by default. There doesn't seem to be a need for this preprocessing to take place.

Ref: https://developercommunity.visualstudio.com/t/ARM64---fatal-error-C1083:-Cannot-open/10119540
Ref: https://github.com/microsoft/cppwinrt/blob/36567e6e647c31caa3d3e5fe6a3219ceb6a78f3f/fast_fwd/fast_fwd.vcxproj#L125-L129

## Question for the NodeJS team

Does `embedded.S` need to be preprocessed at all? VS support [mentioned](https://developercommunity.visualstudio.com/t/ARM64---fatal-error-C1083:-Cannot-open/10119540#T-N10125927) that we can either turn it off altogether or change the `PreprocessedFileName` to something different. In my basic testing, the former seems to work just fine (no preprocessing).

## Testing

The bug can be consistently be reproduced on VS2022 17.4 preview on Windows ARM64 devices (see linked VS Developer Community thread). Reproducing can be done as follows:

```
git clone https://github.com/dennisameling/node -b v16.14.0-arm64
cd node
.\vcbuild.bat arm64 release

....

Creating library ..\..\out\Release\mksnapshot.lib and object ..\..\out\Release\mksnapshot.exp
  mksnapshot.vcxproj -> ..\..\out\Release\\mksnapshot.exe
  generating: "..\..\out\Release\obj\v8_snapshot\/snapshot.cc" "..\..\out\Release\obj\v8_snapshot\/embedded.S"
  Microsoft (R) C/C++ Optimizing Compiler Version 19.34.31721 for ARM64
  Copyright (C) Microsoft Corporation.  All rights reserved.

  cl /c /P /Fi"..\..\out\Release\obj\v8_snapshot\embedded.S" /TC ..\..\out\Release\obj\v8_snapshot\\embedded.S

  embedded.S
..\..\out\Release\obj\v8_snapshot\\embedded.S : fatal error C1083: Cannot open compiler generated file: '..\..\out\Release\obj\v8_snapshot\embedded
.S': Permission denied [C:\node\tools\v8_gypfiles\v8_snapshot.vcxproj]
```

After applying this patch to `tools/gyp/pylib/gyp/generator/msvs.py`, compilation works without issues:

```
.\vcbuild.bat arm64 release

...

     Creating library out\Release\node.lib and object out\Release\node.exp
  Generating code
  0 of 2235 functions ( 0.0%) were compiled, the rest were copied from previous compilation.
    0 functions were new in current compilation
    0 functions had inline decision re-evaluated but remain unchanged
  Finished generating code
  node.vcxproj -> out\Release\\node.exe
Junction created for Release <<===>> out\Release
```
