### PR TITLE
feat: Add command line argument for `gyp --version`

### DIFF
--- a/pylib/gyp/__init__.py
+++ b/pylib/gyp/__init__.py
@@ -15,6 +15,9 @@ import sys
 import traceback
 from gyp.common import GypError
 
+
+VERSION = "0.13.0"
+
 # Default debug modes for GYP
 debug = {}
 
@@ -463,8 +466,18 @@ def gyp_main(args):
         metavar="TARGET",
         help="include only TARGET and its deep dependencies",
     )
+    parser.add_argument(
+        "-V",
+        "--version",
+        dest="version",
+        action="store_true",
+        help="Show the version and exit.",
+    )
 
     options, build_files_arg = parser.parse_args(args)
+    if options.version:
+        print(f"v{VERSION}")
+        return 0
     build_files = build_files_arg
 
     # Set up the configuration directory (defaults to ~/.gyp)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,33 @@
+[metadata]
+name = gyp-next
+version = attr: pylib/gyp.VERSION
+description = A fork of the GYP build system for use in the Node.js projects
+long_description = file: README.md
+long_description_content_type = text/markdown
+author=Node.js contributors
+author_email=ryzokuken@disroot.org
+url=https://github.com/nodejs/gyp-next
+license = BSD 3-Clause License
+classifiers =
+    Development Status :: 3 - Alpha
+    Environment :: Console
+    Intended Audience :: Developers
+    License :: OSI Approved :: BSD License
+    Natural Language :: English
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+
+[options]
+python_requires = 3.6
+package_dir=
+    =pylib
+packages=gyp,gyp.generator
+
+[options.entry_points]
+console_scripts =
+    executable-name = gyp:script_main

--- a/setup.py
+++ b/setup.py
@@ -4,39 +4,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-from os import path
-
 from setuptools import setup
 
-here = path.abspath(path.dirname(__file__))
-# Get the long description from the README file
-with open(path.join(here, "README.md")) as in_file:
-    long_description = in_file.read()
 
-setup(
-    name="gyp-next",
-    version="0.13.0",
-    description="A fork of the GYP build system for use in the Node.js projects",
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    author="Node.js contributors",
-    author_email="ryzokuken@disroot.org",
-    url="https://github.com/nodejs/gyp-next",
-    package_dir={"": "pylib"},
-    packages=["gyp", "gyp.generator"],
-    entry_points={"console_scripts": ["gyp=gyp:script_main"]},
-    python_requires=">=3.6",
-    classifiers=[
-        "Development Status :: 3 - Alpha",
-        "Environment :: Console",
-        "Intended Audience :: Developers",
-        "License :: OSI Approved :: BSD License",
-        "Natural Language :: English",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-    ],
-)
+setup()


### PR DESCRIPTION
Support will be difficult without this basic diagnostic capability. 

DRY says we should not support the version number both in this file and `setup.py`

```
% gyp --version
v0.13.0

% gyp -V
v0.13.0

% gyp --help
usage: usage: gyp_main.py [options ...] [build_file ...]

options:
  -h, --help            show this help message and exit
  [ ... ]
  -V, --version         Show the version and exit.
```