### PR TITLE
chore: setup.cfg: version = attr: gyp.VERSION

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = gyp-next
-version = attr: pylib/gyp.VERSION
+version = attr: gyp.VERSION
 description = A fork of the GYP build system for use in the Node.js projects
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
We need `release.please` to find `VERSION` in the file `pylib/gyp/__init__.py` so according to pypa/setuptools#2596
```
package_dir=
    =pylib

# plus

version = attr: gyp.VERSION
```
should give us the 1-2 punch that `release.please` needs.