### PR TITLE
Why not release-please on demand?

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 name: release-please
 jobs:


### PR DESCRIPTION
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch

Enable repo maintainers to request a release?