### PR TITLE
fix: Move configuration information into pyproject.toml

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -27,6 +27,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools
           pip install --editable ".[dev]"
+      - run: ./gyp -V && ./gyp --version && gyp -V && gyp --version
       - name: Lint with flake8
         run: flake8 . --ignore=E203,W503  --max-complexity=101 --max-line-length=88 --show-source --statistics
       - name: Test with pytest

--- a/pylib/gyp/__init__.py
+++ b/pylib/gyp/__init__.py
@@ -16,8 +16,6 @@ import traceback
 from gyp.common import GypError
 
 
-VERSION = "0.13.0"
-
 # Default debug modes for GYP
 debug = {}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,10 +31,11 @@ classifiers = [
 dev = ["flake8", "pytest"]
 
 [project.scripts]
-gyp = "pylib.gyp:script_main"
+gyp = "gyp:script_main"
 
 [project.urls]
 "Homepage" = "https://github.com/nodejs/gyp-next"
 
 [tool.setuptools]
-packages = ["pylib.gyp", "pylib.gyp.generator"]
+package-dir = {"" = "pylib"}
+packages = ["gyp", "gyp.generator"]


### PR DESCRIPTION
Migrate the contents of `requirements_dev.txt`, `setup.cfg`, and `setup.py` into `pyproject.toml`
* https://packaging.python.org/en/latest/tutorials/packaging-projects
* https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html
* Add a `gyp --version` test to our Python GitHub Action

This PR is required because `release-please` does not recognize `chore:` prefix in #175 despite that prefix being recommended in https://www.conventionalcommits.org and `release-please` creates `chore:` pull requests.

If this does not work, let's upgrade to https://github.com/pypa/gh-action-pypi-publish