### PR TITLE
fix: node.js debugger adds stderr (but exit code is 0) -> shouldn't throw

### DIFF
--- a/pylib/gyp/input.py
+++ b/pylib/gyp/input.py
@@ -961,13 +961,13 @@ def ExpandVariables(input, phase, variables, build_file):
                     # Fix up command with platform specific workarounds.
                     contents = FixupPlatformCommand(contents)
                     try:
-                        p = subprocess.Popen(
+                        # stderr will be printed no matter what
+                        result = subprocess.run(
                             contents,
-                            shell=use_shell,
                             stdout=subprocess.PIPE,
-                            stderr=subprocess.PIPE,
-                            stdin=subprocess.PIPE,
+                            shell=use_shell,
                             cwd=build_file_dir,
+                            check=False
                         )
                     except Exception as e:
                         raise GypError(
@@ -975,20 +975,12 @@ def ExpandVariables(input, phase, variables, build_file):
                             % (e, contents, build_file)
                         )
 
-                    p_stdout, p_stderr = p.communicate("")
-                    p_stdout = p_stdout.decode("utf-8")
-                    p_stderr = p_stderr.decode("utf-8")
-
-                    if p_stderr:
-                        sys.stderr.write(p_stderr)
-                    if p.wait() != 0:
-                        # Simulate check_call behavior, since check_call only exists
-                        # in python 2.5 and later.
+                    if result.returncode > 0:
                         raise GypError(
                             "Call to '%s' returned exit status %d while in %s."
-                            % (contents, p.returncode, build_file)
+                            % (contents, result.returncode, build_file)
                         )
-                    replacement = p_stdout.rstrip()
+                    replacement = result.stdout.decode("utf-8").rstrip()
 
                 cached_command_results[cache_key] = replacement
             else:

--- a/pylib/gyp/input.py
+++ b/pylib/gyp/input.py
@@ -979,8 +979,9 @@ def ExpandVariables(input, phase, variables, build_file):
                     p_stdout = p_stdout.decode("utf-8")
                     p_stderr = p_stderr.decode("utf-8")
 
-                    if p.wait() != 0 or p_stderr:
+                    if p_stderr:
                         sys.stderr.write(p_stderr)
+                    if p.wait() != 0:
                         # Simulate check_call behavior, since check_call only exists
                         # in python 2.5 and later.
                         raise GypError(


### PR DESCRIPTION
https://github.com/nodejs/node-gyp/pull/2719#issuecomment-1266747060

___

Debugger attached.
Waiting for the debugger to disconnect...