### PR TITLE
fix: No build_type in default_variables

### DIFF
--- a/pylib/gyp/__init__.py
+++ b/pylib/gyp/__init__.py
@@ -108,7 +108,9 @@ def Load(
     if default_variables["GENERATOR"] == "ninja":
         default_variables.setdefault(
             "PRODUCT_DIR_ABS",
-            os.path.join(output_dir, "out", default_variables["build_type"]),
+            os.path.join(
+                output_dir, "out", default_variables.get("build_type", "default")
+            ),
         )
     else:
         default_variables.setdefault(


### PR DESCRIPTION
fixes:  #182

Is there a better default value?

Should `default_variables["CONFIGURATION_NAME"]` a few lines further down be modified in a similar way?