### PR TITLE
fix: flake8 extended-ignore

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,6 @@
 [flake8]
 max-complexity = 101
 max-line-length = 88
-extend-ignore = E203  # whitespace before ':' to agree with psf/black
+extend-ignore =
+    # whitespace before ':' to agree with psf/black
+    E203


### PR DESCRIPTION
Fixes: Error code '#' supplied to 'ignore' option does not match '^[A-Z]{1,3}[0-9]{0,3}$'

https://stackoverflow.com/questions/74558565/flake8-error-code-supplied-to-ignore-option-does-not-match-a-z1-30