### PR TITLE
xml.etree.cElementTree was deprecated in Python 3.3

### DIFF
--- a/pylib/gyp/generator/eclipse.py
+++ b/pylib/gyp/generator/eclipse.py
@@ -24,7 +24,7 @@ import gyp
 import gyp.common
 import gyp.msvs_emulation
 import shlex
-import xml.etree.cElementTree as ET
+import xml.etree.ElementTree as ET
 
 generator_wants_static_library_dependencies_adjusted = False
 


### PR DESCRIPTION
https://docs.python.org/3/library/xml.etree.elementtree.html
> _Deprecated since version 3.3_: The `xml.etree.cElementTree` module is deprecated.