### PR TITLE
feat(msvs): add SpectreMitigation attribute

### DIFF
--- a/pylib/gyp/easy_xml_test.py
+++ b/pylib/gyp/easy_xml_test.py
@@ -76,6 +76,7 @@ class TestSequenceFunctions(unittest.TestCase):
             '\'Debug|Win32\'" Label="Configuration">'
             "<ConfigurationType>Application</ConfigurationType>"
             "<CharacterSet>Unicode</CharacterSet>"
+            "<SpectreMitigation>SpectreLoadCF</SpectreMitigation>"
             "</PropertyGroup>"
             "</Project>"
         )
@@ -99,6 +100,7 @@ class TestSequenceFunctions(unittest.TestCase):
                     },
                     ["ConfigurationType", "Application"],
                     ["CharacterSet", "Unicode"],
+                    ["SpectreMitigation", "SpectreLoadCF"]
                 ],
             ]
         )

--- a/pylib/gyp/generator/msvs.py
+++ b/pylib/gyp/generator/msvs.py
@@ -3006,6 +3006,10 @@ def _GetMSBuildConfigurationDetails(spec, build_file):
         character_set = msbuild_attributes.get("CharacterSet")
         config_type = msbuild_attributes.get("ConfigurationType")
         _AddConditionalProperty(properties, condition, "ConfigurationType", config_type)
+        spectre_mitigation = msbuild_attributes.get('SpectreMitigation')
+        if spectre_mitigation:
+            _AddConditionalProperty(properties, condition, "SpectreMitigation",
+                                    spectre_mitigation)
         if config_type == "Driver":
             _AddConditionalProperty(properties, condition, "DriverType", "WDM")
             _AddConditionalProperty(
@@ -3094,6 +3098,8 @@ def _ConvertMSVSBuildAttributes(spec, config, build_file):
             msbuild_attributes[a] = _ConvertMSVSCharacterSet(msvs_attributes[a])
         elif a == "ConfigurationType":
             msbuild_attributes[a] = _ConvertMSVSConfigurationType(msvs_attributes[a])
+        elif a == "SpectreMitigation":
+            msbuild_attributes[a] = msvs_attributes[a]
         else:
             print("Warning: Do not know how to convert MSVS attribute " + a)
     return msbuild_attributes


### PR DESCRIPTION
Backport of https://chromium-review.googlesource.com/c/external/gyp/+/4265144

Description from upstream:
```
Add SpectreMitigation attribute for msvs

This CL allows gyp to recognize the SpectreMitigation msvs_attribute
and add it to the generated vcxproj file for MSBuild.
Possible values for the attribute are Spectre, SpectreLoad,
SpectreLoadCF, and false.

The /Qspectre compiler option is not enough to add
full Spectre mitigation, because even though it causes MSBuild
to add additional instructions to the generated object files,
it does not cause MSBuild to link against Spectre-mitigated
libraries provided by Visual Studio.
```