### PR TITLE
chore: Use Node 16.x in CI

### DIFF
--- a/.github/workflows/node-gyp.yml
+++ b/.github/workflows/node-gyp.yml
@@ -26,7 +26,7 @@ jobs:
           path: node-gyp
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16.x
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}


### PR DESCRIPTION
Node 14.x reached EOL two months ago, which is also around when the tests started to fail.
The tests ran fine locally for me, but then I noticed that the CI file was still using Node 14.