### PR TITLE
chore: Use 3.11 for integration tests

### DIFF
--- a/.github/workflows/node-gyp.yml
+++ b/.github/workflows/node-gyp.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python: ["3.7", "3.11"]
+        python: ["3.8", "3.x"]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/node-gyp.yml
+++ b/.github/workflows/node-gyp.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python: ["3.7", "3.10"]
+        python: ["3.7", "3.11"]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/pylib/gyp/easy_xml.py
+++ b/pylib/gyp/easy_xml.py
@@ -121,7 +121,11 @@ def WriteXmlIfChanged(content, path, encoding="utf-8", pretty=False,
     if win32 and os.linesep != "\r\n":
         xml_string = xml_string.replace("\n", "\r\n")
 
-    default_encoding = locale.getdefaultlocale()[1]
+    if sys.version_info >= (3, 11):
+        default_encoding = locale.getencoding()
+    else:
+        default_encoding = locale.getdefaultlocale()[1]
+
     if default_encoding and default_encoding.upper() != encoding.upper():
         xml_string = xml_string.encode(encoding)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,7 @@ ignore = [
   "PLW0603",
   "PLW2901",
   "RUF005",
+  "RUF012",
   "UP031",
 ]
 line-length = 88


### PR DESCRIPTION
This PR changes the CI to use Python 3.11 instead of 3.10, and attempts to fix a small deprecation warning.

It also adds a new lint ignore rule for ruff because CI gave the following errors:
```
Run ruff --format=github .
Error: pylib/gyp/generator/ninja.py:2095:24: RUF012 Mutable class attributes should be annotated with `typing.ClassVar`
Error: pylib/gyp/xcode_emulation.py:153:23: RUF012 Mutable class attributes should be annotated with `typing.ClassVar`
Error: pylib/gyp/xcode_emulation.py:154:28: RUF012 Mutable class attributes should be annotated with `typing.ClassVar`
Error: pylib/gyp/xcode_emulation.py:155:23: RUF012 Mutable class attributes should be annotated with `typing.ClassVar`
Error: pylib/gyp/xcode_emulation.py:159:20: RUF012 Mutable class attributes should be annotated with `typing.ClassVar`
Error: pylib/gyp/xcode_emulation.py:163:30: RUF012 Mutable class attributes should be annotated with `typing.ClassVar`
Error: pylib/gyp/xcodeproj_file.py:268:15: RUF012 Mutable class attributes should be annotated with `typing.ClassVar`
Error: pylib/gyp/xcodeproj_file.py:272:26: RUF012 Mutable class attributes should be annotated with `typing.ClassVar`
Error: pylib/gyp/xcodeproj_file.py:285:36: RUF012 Mutable class attributes should be annotated with `typing.ClassVar`
Error: pylib/gyp/xcodeproj_file.py:1685:16: RUF012 Mutable class attributes should be annotated with `typing.ClassVar`
Error: pylib/gyp/xcodeproj_file.py:2071:36: RUF012 Mutable class attributes should be annotated with `typing.ClassVar`
Error: pylib/gyp/xcodeproj_file.py:2080:37: RUF012 Mutable class attributes should be annotated with `typing.ClassVar`
Error: pylib/gyp/xcodeproj_file.py:2460:26: RUF012 Mutable class attributes should be annotated with `typing.ClassVar`
Error: Process completed with exit code 1.
```