### PR TITLE
fix: some Python lint issues

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
-      max-parallel: 6
+      max-parallel: 5
       matrix:
         os: [macos-latest, ubuntu-latest] # , windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12-dev"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/pylib/gyp/easy_xml.py
+++ b/pylib/gyp/easy_xml.py
@@ -121,10 +121,10 @@ def WriteXmlIfChanged(content, path, encoding="utf-8", pretty=False,
     if win32 and os.linesep != "\r\n":
         xml_string = xml_string.replace("\n", "\r\n")
 
-    if sys.version_info >= (3, 11):
-        default_encoding = locale.getencoding()
-    else:
+    try:  # getdefaultlocale() was removed in Python 3.11
         default_encoding = locale.getdefaultlocale()[1]
+    except AttributeError:
+        default_encoding = locale.getencoding()
 
     if default_encoding and default_encoding.upper() != encoding.upper():
         xml_string = xml_string.encode(encoding)

--- a/pylib/gyp/generator/make.py
+++ b/pylib/gyp/generator/make.py
@@ -1989,10 +1989,7 @@ $(obj).$(TOOLSET)/$(TARGET)/%%.o: $(obj)/%%%s FORCE_DO_CMD
                 and self.toolset == "target"
             ):
                 # On mac, products are created in install_path immediately.
-                assert install_path == self.output, "{} != {}".format(
-                    install_path,
-                    self.output,
-                )
+                assert install_path == self.output, f"{install_path} != {self.output}"
 
             # Point the target alias to the final binary output.
             self.WriteMakeRule(

--- a/pylib/gyp/generator/msvs.py
+++ b/pylib/gyp/generator/msvs.py
@@ -684,7 +684,7 @@ def _GenerateExternalRules(rules, output_dir, spec, sources, options, actions_to
             all_outputs.update(OrderedSet(outputs))
             # Only use one target from each rule as the dependency for
             # 'all' so we don't try to build each rule multiple times.
-            first_outputs.append(list(outputs)[0])
+            first_outputs.append(next(iter(outputs)))
             # Get the unique output directories for this rule.
             output_dirs = [os.path.split(i)[0] for i in outputs]
             for od in output_dirs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 description = "A fork of the GYP build system for use in the Node.js projects"
 readme = "README.md"
 license = { file="LICENSE" }
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Environment :: Console",
@@ -20,7 +20,6 @@ classifiers = [
     "Natural Language :: English",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
Related to nodejs/node-gyp#2886

% `ruff .`
```
pylib/gyp/generator/make.py:1992:53: UP032 [*] Use f-string instead of `format` call
pylib/gyp/generator/msvs.py:687:34: RUF015 [*] Prefer `next(iter(outputs))` over `list(outputs)[0]`
```

% `ruff --fix .`
```
Found 2 errors (2 fixed, 0 remaining).
```