### PR TITLE
Fix PLR1714 lint errors

### DIFF
--- a/pylib/gyp/MSVSSettings.py
+++ b/pylib/gyp/MSVSSettings.py
@@ -141,7 +141,7 @@ class _Boolean(_Type):
     """Boolean settings, can have the values 'false' or 'true'."""
 
     def _Validate(self, value):
-        if value != "true" and value != "false":
+        if value not in {"true", "false"}:
             raise ValueError("expected bool; got %r" % value)
 
     def ValidateMSVS(self, value):

--- a/pylib/gyp/generator/analyzer.py
+++ b/pylib/gyp/generator/analyzer.py
@@ -379,7 +379,7 @@ def _GenerateTargets(data, target_list, target_dicts, toplevel_dir, files, build
         target.is_executable = target_type == "executable"
         target.is_static_library = target_type == "static_library"
         target.is_or_has_linked_ancestor = (
-            target_type == "executable" or target_type == "shared_library"
+            target_type in {"executable", "shared_library"}
         )
 
         build_file = gyp.common.ParseQualifiedTarget(target_name)[0]
@@ -451,8 +451,8 @@ def _DoesTargetDependOnMatchingTargets(target):
     if target.match_status == MATCH_STATUS_DOESNT_MATCH:
         return False
     if (
-        target.match_status == MATCH_STATUS_MATCHES
-        or target.match_status == MATCH_STATUS_MATCHES_BY_DEPENDENCY
+        target.match_status in {MATCH_STATUS_MATCHES,
+                                MATCH_STATUS_MATCHES_BY_DEPENDENCY}
     ):
         return True
     for dep in target.deps:

--- a/pylib/gyp/generator/android.py
+++ b/pylib/gyp/generator/android.py
@@ -697,7 +697,7 @@ class AndroidMkWriter:
                 target,
             )
 
-        if self.type != "static_library" and self.type != "shared_library":
+        if self.type not in {"static_library", "shared_library"}:
             target_prefix = spec.get("product_prefix", target_prefix)
             target = spec.get("product_name", target)
             product_ext = spec.get("product_extension")

--- a/pylib/gyp/generator/make.py
+++ b/pylib/gyp/generator/make.py
@@ -2028,7 +2028,7 @@ $(obj).$(TOOLSET)/$(TARGET)/%%.o: $(obj)/%%%s FORCE_DO_CMD
                 installable_deps.append(
                     self.GetUnversionedSidedeckFromSidedeck(install_path)
                 )
-            if self.output != self.alias and self.alias != self.target:
+            if self.alias not in (self.output, self.target):
                 self.WriteMakeRule(
                     [self.alias],
                     installable_deps,

--- a/pylib/gyp/generator/make.py
+++ b/pylib/gyp/generator/make.py
@@ -1063,7 +1063,7 @@ $(obj).$(TOOLSET)/$(TARGET)/%%.o: $(obj)/%%%s FORCE_DO_CMD
             # libraries, but until everything is made cross-compile safe, also use
             # target libraries.
             # TODO(piman): when everything is cross-compile safe, remove lib.target
-            if self.flavor == "zos" or self.flavor == "aix":
+            if self.flavor in {"zos", "aix"}:
                 self.WriteLn(
                     "cmd_%s = LIBPATH=$(builddir)/lib.host:"
                     "$(builddir)/lib.target:$$LIBPATH; "

--- a/pylib/gyp/input.py
+++ b/pylib/gyp/input.py
@@ -1576,14 +1576,12 @@ def ExpandWildcardDependencies(targets, data):
                         continue
                     dependency_target_name = dependency_target_dict["target_name"]
                     if (
-                        dependency_target != "*"
-                        and dependency_target != dependency_target_name
+                        dependency_target not in {"*", dependency_target_name}
                     ):
                         continue
                     dependency_target_toolset = dependency_target_dict["toolset"]
                     if (
-                        dependency_toolset != "*"
-                        and dependency_toolset != dependency_target_toolset
+                        dependency_toolset not in {"*", dependency_target_toolset}
                     ):
                         continue
                     dependency = gyp.common.QualifiedTarget(
@@ -2541,7 +2539,7 @@ def ProcessListFiltersInDict(name, the_dict):
     del_lists = []
     for key, value in the_dict.items():
         operation = key[-1]
-        if operation != "!" and operation != "/":
+        if operation not in {"!", "/"}:
             continue
 
         if type(value) is not list:

--- a/pylib/gyp/xcodeproj_file.py
+++ b/pylib/gyp/xcodeproj_file.py
@@ -971,7 +971,7 @@ class XCHierarchicalElement(XCObject):
         if "path" in self._properties and "name" not in self._properties:
             path = self._properties["path"]
             name = posixpath.basename(path)
-            if name != "" and path != name:
+            if name not in {"", path}:
                 self.SetProperty("name", name)
 
         if "path" in self._properties and (

--- a/pylib/gyp/xcodeproj_file.py
+++ b/pylib/gyp/xcodeproj_file.py
@@ -971,7 +971,7 @@ class XCHierarchicalElement(XCObject):
         if "path" in self._properties and "name" not in self._properties:
             path = self._properties["path"]
             name = posixpath.basename(path)
-            if name not in {"", path}:
+            if name not in ("", path):
                 self.SetProperty("name", name)
 
         if "path" in self._properties and (

--- a/pylib/gyp/xcodeproj_file.py
+++ b/pylib/gyp/xcodeproj_file.py
@@ -2546,10 +2546,10 @@ class PBXNativeTarget(XCTarget):
                         force_extension = suffix[1:]
 
                 if (
-                    self._properties["productType"]
-                    == "com.apple.product-type-bundle.unit.test"
-                    or self._properties["productType"]
-                    == "com.apple.product-type-bundle.ui-testing"
+                    self._properties["productType"] in {
+                        "com.apple.product-type-bundle.unit.test",
+                        "com.apple.product-type-bundle.ui-testing"
+                    }
                 ) and force_extension is None:
                     force_extension = suffix[1:]
 
@@ -2700,8 +2700,10 @@ class PBXNativeTarget(XCTarget):
                 other._properties["productType"] == static_library_type
                 or (
                     (
-                        other._properties["productType"] == shared_library_type
-                        or other._properties["productType"] == framework_type
+                        other._properties["productType"] in {
+                            shared_library_type,
+                            framework_type
+                        }
                     )
                     and (
                         (not other.HasBuildSetting("MACH_O_TYPE"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ select = [
   "ICN",  # flake8-import-conventions
   "INT",  # flake8-gettext
   "PL",   # Pylint
+  "PLR",  # Pylint
   "PYI",  # flake8-pyi
   "RSE",  # flake8-raise
   "RUF",  # Ruff-specific rules

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ select = [
   "ICN",  # flake8-import-conventions
   "INT",  # flake8-gettext
   "PL",   # Pylint
-  "PLR",  # Pylint
   "PYI",  # flake8-pyi
   "RSE",  # flake8-raise
   "RUF",  # Ruff-specific rules

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,12 +86,14 @@ select = [
   # "TRY",  # tryceratops
 ]
 ignore = [
+  "E721",
   "PLC1901",
   "PLR0402",
   "PLR2004",
   "PLR5501",
   "PLW0603",
   "PLW2901",
+  "PYI024",
   "RUF005",
   "RUF012",
   "UP031",


### PR DESCRIPTION
% `ruff rule PLR1714`
# repeated-equality-comparison-target (PLR1714)

Derived from the **Pylint** linter.

## What it does
Checks for repeated equality comparisons that can be rewritten as a membership test.

## Why is this bad?
To check if a variable is equal to one of many values, it is common to write a series of equality comparisons (e.g., `foo == "bar" or foo == "baz"`).

Instead, prefer to combine the values into a collection and use the `in` operator to check for membership, which is more performant and succinct.
If the items are hashable, use a `set` for efficiency; otherwise, use a `tuple`.

## Example
```python
foo == "bar" or foo == "baz" or foo == "qux"
```

Use instead:
```python
foo in {"bar", "baz", "qux"}
```

## References
- [Python documentation: Comparisons](https://docs.python.org/3/reference/expressions.html#comparisons)
- [Python documentation: Membership test operations](https://docs.python.org/3/reference/expressions.html#membership-test-operations)
- [Python documentation: `set`](https://docs.python.org/3/library/stdtypes.html#set)