### PR TITLE
fixed issue that occurs when sources returns a string

### DIFF
--- a/pylib/gyp/generator/make.py
+++ b/pylib/gyp/generator/make.py
@@ -907,7 +907,8 @@ $(obj).$(TOOLSET)/$(TARGET)/%%.o: $(obj)/%%%s FORCE_DO_CMD
             self.WriteMacInfoPlist(mac_bundle_deps)
 
         # Sources.
-        all_sources = spec.get("sources", []) + extra_sources
+        sources = spec.get("sources",[])
+        all_sources = [sources] + extra_sources if isinstance(sources,str) else extra_sources + sources
         if all_sources:
             self.WriteSources(
                 configs,


### PR DESCRIPTION
Error occurred while attempting to run node-gyp configure while using python 3.11.4 on ARM MacO

sources returned a string instead of a list.

```
turtle@mac nodecc % node-gyp configure                                                               [1194/1197]
gyp info it worked if it ends with ok                                                                                                        
gyp info using node-gyp@9.4.0                                                                                                                
gyp info using node@18.16.0 | darwin | arm64                                                                                                 
gyp info find Python using Python version 3.11.4 found at "/opt/homebrew/opt/python@3.11/bin/python3.11"                                     
gyp info spawn /opt/homebrew/opt/python@3.11/bin/python3.11                                                                                  
gyp info spawn args [                                                                                                                        
gyp info spawn args   '/usr/local/lib/node_modules/node-gyp/gyp/gyp_main.py',                                                                
gyp info spawn args   'binding.gyp',                                                                                                         
gyp info spawn args   '-f',                                                                                                                  
gyp info spawn args   'make',                                                                                                                
gyp info spawn args   '-I',                                                                                                                  
gyp info spawn args   '/Users/calonso/Desktop/Code/nodecc/build/config.gypi',                                                                
gyp info spawn args   '-I',                                                                                                                  
gyp info spawn args   '/usr/local/lib/node_modules/node-gyp/addon.gypi',                                                                     
gyp info spawn args   '-I',                                                                                                                  
gyp info spawn args   '/Users/calonso/Library/Caches/node-gyp/18.16.0/include/node/common.gypi',                                             
gyp info spawn args   '-Dlibrary=shared_library',                                                                                            
gyp info spawn args   '-Dvisibility=default',                                                                                                
gyp info spawn args   '-Dnode_root_dir=/Users/calonso/Library/Caches/node-gyp/18.16.0',                                                      
gyp info spawn args   '-Dnode_gyp_dir=/usr/local/lib/node_modules/node-gyp',                                                                 
gyp info spawn args   '-Dnode_lib_file=/Users/calonso/Library/Caches/node-gyp/18.16.0/<(target_arch)/node.lib',                              
gyp info spawn args   '-Dmodule_root_dir=/Users/calonso/Desktop/Code/nodecc',                                                                
gyp info spawn args   '-Dnode_engine=v8',                                                                                                    
gyp info spawn args   '--depth=.',                                                                                                           
gyp info spawn args   '--no-parallel',                                                                                                       
gyp info spawn args   '--generator-output',                                                                                                  
gyp info spawn args   'build',                                                                                                               
gyp info spawn args   '-Goutput_dir=.'                                                                                                       
gyp info spawn args ]                                                                                                                        
Traceback (most recent call last):                                                                                                           
  File "/usr/local/lib/node_modules/node-gyp/gyp/gyp_main.py", line 45, in <module>                                                          
    sys.exit(gyp.script_main())                                                                                                              
             ^^^^^^^^^^^^^^^^^                                                                                                               
  File "/usr/local/lib/node_modules/node-gyp/gyp/pylib/gyp/__init__.py", line 686, in script_main                                            
    return main(sys.argv[1:])                                                                                                                
           ^^^^^^^^^^^^^^^^^^                                                                                                                
  File "/usr/local/lib/node_modules/node-gyp/gyp/pylib/gyp/__init__.py", line 678, in main                                                   
    return gyp_main(args)                                                                                                                    
           ^^^^^^^^^^^^^^                                                                                                                    
  File "/usr/local/lib/node_modules/node-gyp/gyp/pylib/gyp/__init__.py", line 663, in gyp_main                                               
    generator.GenerateOutput(flat_list, targets, data, params)                                                                               
  File "/usr/local/lib/node_modules/node-gyp/gyp/pylib/gyp/generator/make.py", line 2654, in GenerateOutput                                  
    writer.Write(                                                                                                                            
  File "/usr/local/lib/node_modules/node-gyp/gyp/pylib/gyp/generator/make.py", line 913, in Write                                            
    all_sources = spec.get("sources", []) + extra_sources                                                                                    
                  ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~                                                                                    
TypeError: can only concatenate str (not "list") to str                                                                                      
gyp ERR! configure error                                                                                                                     
gyp ERR! stack Error: `gyp` failed with exit code: 1                                                                                         
gyp ERR! stack     at ChildProcess.onCpExit (/usr/local/lib/node_modules/node-gyp/lib/configure.js:325:16)                                   
gyp ERR! stack     at ChildProcess.emit (node:events:513:28)                                                                                 
gyp ERR! stack     at ChildProcess._handle.onexit (node:internal/child_process:291:12)                                                       
gyp ERR! System Darwin 22.1.0                                                                                                                
gyp ERR! command "/usr/local/bin/node" "/usr/local/bin/node-gyp" "configure"                                                                 
gyp ERR! cwd /Users/calonso/Desktop/Code/nodecc                                                                                              
gyp ERR! node -v v18.16.0                                                                                                                    
gyp ERR! node-gyp -v v9.4.0                                                                                                                  
gyp ERR! not ok 
```