### PR TITLE
feat: add VCToolsVersion for msvs

### DIFF
--- a/.github/workflows/nodejs-windows.yml
+++ b/.github/workflows/nodejs-windows.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build-windows:
-    runs-on: windows-2019
+    runs-on: windows-latest
     steps:
       - name: Clone gyp-next
         uses: actions/checkout@v3

--- a/pylib/gyp/easy_xml_test.py
+++ b/pylib/gyp/easy_xml_test.py
@@ -77,6 +77,7 @@ class TestSequenceFunctions(unittest.TestCase):
             "<ConfigurationType>Application</ConfigurationType>"
             "<CharacterSet>Unicode</CharacterSet>"
             "<SpectreMitigation>SpectreLoadCF</SpectreMitigation>"
+            "<VCToolsVersion>14.36.32532</VCToolsVersion>"
             "</PropertyGroup>"
             "</Project>"
         )
@@ -100,7 +101,8 @@ class TestSequenceFunctions(unittest.TestCase):
                     },
                     ["ConfigurationType", "Application"],
                     ["CharacterSet", "Unicode"],
-                    ["SpectreMitigation", "SpectreLoadCF"]
+                    ["SpectreMitigation", "SpectreLoadCF"],
+                    ["VCToolsVersion", "14.36.32532"],
                 ],
             ]
         )

--- a/pylib/gyp/generator/msvs.py
+++ b/pylib/gyp/generator/msvs.py
@@ -3004,6 +3004,7 @@ def _GetMSBuildConfigurationDetails(spec, build_file):
         msbuild_attributes = _GetMSBuildAttributes(spec, settings, build_file)
         condition = _GetConfigurationCondition(name, settings, spec)
         character_set = msbuild_attributes.get("CharacterSet")
+        vctools_version = msbuild_attributes.get("VCToolsVersion")
         config_type = msbuild_attributes.get("ConfigurationType")
         _AddConditionalProperty(properties, condition, "ConfigurationType", config_type)
         spectre_mitigation = msbuild_attributes.get('SpectreMitigation')
@@ -3018,6 +3019,10 @@ def _GetMSBuildConfigurationDetails(spec, build_file):
         if character_set and "msvs_enable_winrt" not in spec:
             _AddConditionalProperty(
                 properties, condition, "CharacterSet", character_set
+            )
+        if vctools_version and "msvs_enable_winrt" not in spec:
+            _AddConditionalProperty(
+                properties, condition, "VCToolsVersion", vctools_version
             )
     return _GetMSBuildPropertyGroup(spec, "Configuration", properties)
 
@@ -3099,6 +3104,8 @@ def _ConvertMSVSBuildAttributes(spec, config, build_file):
         elif a == "ConfigurationType":
             msbuild_attributes[a] = _ConvertMSVSConfigurationType(msvs_attributes[a])
         elif a == "SpectreMitigation":
+            msbuild_attributes[a] = msvs_attributes[a]
+        elif a == "VCToolsVersion":
             msbuild_attributes[a] = msvs_attributes[a]
         else:
             print("Warning: Do not know how to convert MSVS attribute " + a)


### PR DESCRIPTION
Add the ability to specify the 'MSVC toolset version' <VCToolsVersion> for the VisualStudio platform.

This PR created for gyp-next, following the adviced in node-gyp. Thank you.
[https://github.com/nodejs/node-gyp/pull/2910](https://github.com/nodejs/node-gyp/pull/2910)

Usage example for binding.gyp

```
'targets': [
 {
   'configurations': {
     'Debug': {
       "msvs_configuration_attributes": {
         "VCToolsVersion": "14.36.32532",
```

Thank you and best regards.