### PR TITLE
chore(main): ruff --output-format=github .

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -30,7 +30,7 @@ jobs:
           pip install --editable ".[dev]"
       - run: ./gyp -V && ./gyp --version && gyp -V && gyp --version
       - name: Lint with ruff  # See pyproject.toml for settings
-        run: ruff --format=github .
+        run: ruff --output-format=github .
       - name: Test with pytest  # See pyproject.toml for settings
         run: pytest
       # - name: Run doctests with pytest


### PR DESCRIPTION
Ruff changed `--format` to `--output-format` because they are adding a formatter similar to `psf/black`.