### PR TITLE
fix: error format requires a mapping

### DIFF
--- a/pylib/gyp/__init__.py
+++ b/pylib/gyp/__init__.py
@@ -550,7 +550,7 @@ def gyp_main(args):
     if not build_files:
         build_files = FindBuildFiles()
     if not build_files:
-        raise GypError((usage + "\n\n%s: error: no build_file") % (my_name, my_name))
+        raise GypError((usage + "\n\n%(prog)s: error: no build_file") % {"prog": my_name, "prog": my_name})
 
     # TODO(mark): Chromium-specific hack!
     # For Chromium, the gyp "depth" variable should always be a relative path


### PR DESCRIPTION
Fix:

run `gyp` without arguments doesn't show right *usage*

````console
c108df569f5e:/work# gyp
Traceback (most recent call last):
  File "/usr/bin/gyp", line 8, in <module>
    sys.exit(script_main())
             ^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/gyp/__init__.py", line 688, in script_main
    return main(sys.argv[1:])
           ^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/gyp/__init__.py", line 680, in main
    return gyp_main(args)
           ^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/gyp/__init__.py", line 553, in gyp_main
    raise GypError((usage + "\n\n%s: error: no build_file") % (my_name, my_name))
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
TypeError: format requires a mapping
c108df569f5e:/work#
````