### PR TITLE
fix: do not assume that /usr/bin/env exists on macOS

### DIFF
--- a/pylib/gyp/generator/make.py
+++ b/pylib/gyp/generator/make.py
@@ -25,6 +25,7 @@
 import os
 import re
 import subprocess
+import sys
 import gyp
 import gyp.common
 import gyp.xcode_emulation
@@ -207,7 +208,7 @@ cmd_solink_module = $(LINK.$(TOOLSET)) -o $@ -shared $(GYP_LDFLAGS) $(LDFLAGS.$(
 
 LINK_COMMANDS_MAC = """\
 quiet_cmd_alink = LIBTOOL-STATIC $@
-cmd_alink = rm -f $@ && ./gyp-mac-tool filter-libtool libtool $(GYP_LIBTOOLFLAGS) -static -o $@ $(filter %.o,$^)
+cmd_alink = rm -f $@ && %(python)s gyp-mac-tool filter-libtool libtool $(GYP_LIBTOOLFLAGS) -static -o $@ $(filter %%.o,$^)
 
 quiet_cmd_link = LINK($(TOOLSET)) $@
 cmd_link = $(LINK.$(TOOLSET)) $(GYP_LDFLAGS) $(LDFLAGS.$(TOOLSET)) -o "$@" $(LD_INPUTS) $(LIBS)
@@ -217,7 +218,7 @@ cmd_solink = $(LINK.$(TOOLSET)) -shared $(GYP_LDFLAGS) $(LDFLAGS.$(TOOLSET)) -o 
 
 quiet_cmd_solink_module = SOLINK_MODULE($(TOOLSET)) $@
 cmd_solink_module = $(LINK.$(TOOLSET)) -bundle $(GYP_LDFLAGS) $(LDFLAGS.$(TOOLSET)) -o $@ $(filter-out FORCE_DO_CMD, $^) $(LIBS)
-"""  # noqa: E501
+""" % {'python': sys.executable}  # noqa: E501
 
 LINK_COMMANDS_ANDROID = """\
 quiet_cmd_alink = AR($(TOOLSET)) $@
@@ -600,14 +601,14 @@ cmd_pch_mm = $(CC.$(TOOLSET)) $(GYP_PCH_OBJCXXFLAGS) $(DEPFLAGS) -c -o $@ $<
 # Use $(4) for the command, since $(2) and $(3) are used as flag by do_cmd
 # already.
 quiet_cmd_mac_tool = MACTOOL $(4) $<
-cmd_mac_tool = ./gyp-mac-tool $(4) $< "$@"
+cmd_mac_tool = %(python)s gyp-mac-tool $(4) $< "$@"
 
 quiet_cmd_mac_package_framework = PACKAGE FRAMEWORK $@
-cmd_mac_package_framework = ./gyp-mac-tool package-framework "$@" $(4)
+cmd_mac_package_framework = %(python)s gyp-mac-tool package-framework "$@" $(4)
 
 quiet_cmd_infoplist = INFOPLIST $@
 cmd_infoplist = $(CC.$(TOOLSET)) -E -P -Wno-trigraphs -x c $(INFOPLIST_DEFINES) "$<" -o "$@"
-"""  # noqa: E501
+""" % {'python': sys.executable}  # noqa: E501
 
 
 def WriteRootHeaderSuffixRules(writer):
@@ -2464,7 +2465,7 @@ def GenerateOutput(target_list, target_dicts, data, params):
         "PLI.host": GetEnvironFallback(("PLI_host", "PLI"), "pli"),
     }
     if flavor == "mac":
-        flock_command = "./gyp-mac-tool flock"
+        flock_command = "%s gyp-mac-tool flock" % sys.executable
         header_params.update(
             {
                 "flock": flock_command,
@@ -2514,7 +2515,7 @@ def GenerateOutput(target_list, target_dicts, data, params):
         header_params.update(
             {
                 "copy_archive_args": copy_archive_arguments,
-                "flock": "./gyp-flock-tool flock",
+                "flock": "%s gyp-flock-tool flock" % sys.executable,
                 "flock_index": 2,
             }
         )
@@ -2530,7 +2531,7 @@ def GenerateOutput(target_list, target_dicts, data, params):
             {
                 "copy_archive_args": copy_archive_arguments,
                 "link_commands": LINK_COMMANDS_AIX,
-                "flock": "./gyp-flock-tool flock",
+                "flock": "%s gyp-flock-tool flock" % sys.executable,
                 "flock_index": 2,
             }
         )
@@ -2540,7 +2541,7 @@ def GenerateOutput(target_list, target_dicts, data, params):
             {
                 "copy_archive_args": copy_archive_arguments,
                 "link_commands": LINK_COMMANDS_OS400,
-                "flock": "./gyp-flock-tool flock",
+                "flock": "%s gyp-flock-tool flock" % sys.executable,
                 "flock_index": 2,
             }
         )

--- a/pylib/gyp/generator/ninja.py
+++ b/pylib/gyp/generator/ninja.py
@@ -2593,9 +2593,9 @@ def GenerateOutputForConfig(target_list, target_dicts, data, params, config_name
             "alink",
             description="LIBTOOL-STATIC $out, POSTBUILDS",
             command="rm -f $out && "
-            "./gyp-mac-tool filter-libtool libtool $libtool_flags "
+            "%s gyp-mac-tool filter-libtool libtool $libtool_flags "
             "-static -o $out $in"
-            "$postbuilds",
+            "$postbuilds" % sys.executable,
         )
         master_ninja.rule(
             "lipo",
@@ -2696,41 +2696,44 @@ def GenerateOutputForConfig(target_list, target_dicts, data, params, config_name
         master_ninja.rule(
             "copy_infoplist",
             description="COPY INFOPLIST $in",
-            command="$env ./gyp-mac-tool copy-info-plist $in $out $binary $keys",
+            command="$env %s gyp-mac-tool copy-info-plist $in $out $binary $keys"
+            % sys.executable,
         )
         master_ninja.rule(
             "merge_infoplist",
             description="MERGE INFOPLISTS $in",
-            command="$env ./gyp-mac-tool merge-info-plist $out $in",
+            command="$env %s gyp-mac-tool merge-info-plist $out $in" % sys.executable,
         )
         master_ninja.rule(
             "compile_xcassets",
             description="COMPILE XCASSETS $in",
-            command="$env ./gyp-mac-tool compile-xcassets $keys $in",
+            command="$env %s gyp-mac-tool compile-xcassets $keys $in" % sys.executable,
         )
         master_ninja.rule(
             "compile_ios_framework_headers",
             description="COMPILE HEADER MAPS AND COPY FRAMEWORK HEADERS $in",
-            command="$env ./gyp-mac-tool compile-ios-framework-header-map $out "
-            "$framework $in && $env ./gyp-mac-tool "
-            "copy-ios-framework-headers $framework $copy_headers",
+            command="$env %(python)s gyp-mac-tool compile-ios-framework-header-map "
+            "$out $framework $in && $env %(python)s gyp-mac-tool "
+            "copy-ios-framework-headers $framework $copy_headers"
+            % {'python': sys.executable},
         )
         master_ninja.rule(
             "mac_tool",
             description="MACTOOL $mactool_cmd $in",
-            command="$env ./gyp-mac-tool $mactool_cmd $in $out $binary",
+            command="$env %s gyp-mac-tool $mactool_cmd $in $out $binary"
+            % sys.executable,
         )
         master_ninja.rule(
             "package_framework",
             description="PACKAGE FRAMEWORK $out, POSTBUILDS",
-            command="./gyp-mac-tool package-framework $out $version$postbuilds "
-            "&& touch $out",
+            command="%s gyp-mac-tool package-framework $out $version$postbuilds "
+            "&& touch $out" % sys.executable,
         )
         master_ninja.rule(
             "package_ios_framework",
             description="PACKAGE IOS FRAMEWORK $out, POSTBUILDS",
-            command="./gyp-mac-tool package-ios-framework $out $postbuilds "
-            "&& touch $out",
+            command="%s gyp-mac-tool package-ios-framework $out $postbuilds "
+            "&& touch $out" % sys.executable,
         )
     if flavor == "win":
         master_ninja.rule(

--- a/pylib/gyp/xcode_emulation.py
+++ b/pylib/gyp/xcode_emulation.py
@@ -1174,8 +1174,9 @@ class XcodeSettings:
                 # Then re-sign everything with 'preserve=True'
                 postbuilds.extend(
                     [
-                        '%s code-sign-bundle "%s" "%s" "%s" "%s" %s'
+                        '%s %s code-sign-bundle "%s" "%s" "%s" "%s" %s'
                         % (
+                            sys.executable,
                             os.path.join("${TARGET_BUILD_DIR}", "gyp-mac-tool"),
                             key,
                             settings.get("CODE_SIGN_ENTITLEMENTS", ""),
@@ -1190,8 +1191,9 @@ class XcodeSettings:
             for target in targets:
                 postbuilds.extend(
                     [
-                        '%s code-sign-bundle "%s" "%s" "%s" "%s" %s'
+                        '%s %s code-sign-bundle "%s" "%s" "%s" "%s" %s'
                         % (
+                            sys.executable,
                             os.path.join("${TARGET_BUILD_DIR}", "gyp-mac-tool"),
                             key,
                             settings.get("CODE_SIGN_ENTITLEMENTS", ""),
@@ -1204,8 +1206,9 @@ class XcodeSettings:
 
         postbuilds.extend(
             [
-                '%s code-sign-bundle "%s" "%s" "%s" "%s" %s'
+                '%s %s code-sign-bundle "%s" "%s" "%s" "%s" %s'
                 % (
+                    sys.executable,
                     os.path.join("${TARGET_BUILD_DIR}", "gyp-mac-tool"),
                     key,
                     settings.get("CODE_SIGN_ENTITLEMENTS", ""),


### PR DESCRIPTION
This changes fixes build error when `/usr/bin/env` is not available (for example, when building in Nix sandbox). It makes gyp-generated build configurations invoke Python directly on the gyp tools (similar to `gyp-win-tool` that uses sys.executable on Windows).

See also https://github.com/NixOS/nixpkgs/issues/261820 and https://github.com/NixOS/nixpkgs/pull/248708