### PR TITLE
fix: add quotes for command in msvs generator

### DIFF
--- a/pylib/gyp/generator/msvs.py
+++ b/pylib/gyp/generator/msvs.py
@@ -435,6 +435,7 @@ def _BuildCommandLineForRuleRaw(
             # Support a mode for using cmd directly.
             # Convert any paths to native form (first element is used directly).
             # TODO(quote):  regularize quoting path names throughout the module
+            command[1] = '"%s"' % command[1]
             arguments = ['"%s"' % i for i in arguments]
         # Collapse into a single command.
         return input_dir_preamble + " ".join(command + arguments)


### PR DESCRIPTION
The msvs generator only added quotes for arguments of the action, the command itself should have quotes too.

Without this change actions will fail when python binary is placed in a path with spaces in it.

Refs https://github.com/nodejs/node/pull/48462.

/cc @gengjiawen 