### PR TITLE
feat: generate compile_commands.json with ninja

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
+      - uses: seanmiddleditch/gha-setup-ninja@v4
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools

--- a/data/ninja/build.ninja
+++ b/data/ninja/build.ninja
@@ -1,0 +1,4 @@
+rule cc
+  command = cc $in $out
+
+build my.out: cc my.in

--- a/pylib/gyp/generator/ninja.py
+++ b/pylib/gyp/generator/ninja.py
@@ -11,6 +11,7 @@ import multiprocessing
 import os.path
 import re
 import signal
+import shutil
 import subprocess
 import sys
 import gyp
@@ -2210,6 +2211,7 @@ def GenerateOutputForConfig(target_list, target_dicts, data, params, config_name
     options = params["options"]
     flavor = gyp.common.GetFlavor(params)
     generator_flags = params.get("generator_flags", {})
+    generate_compile_commands = generator_flags.get("compile_commands", False)
 
     # build_dir: relative path from source root to our output files.
     # e.g. "out/Debug"
@@ -2877,6 +2879,35 @@ def GenerateOutputForConfig(target_list, target_dicts, data, params, config_name
         master_ninja.default(generator_flags.get("default_target", "all"))
 
     master_ninja_file.close()
+
+    if generate_compile_commands:
+        compile_db = GenerateCompileDBWithNinja(toplevel_build)
+        compile_db_file = OpenOutput(
+            os.path.join(toplevel_build, "compile_commands.json")
+        )
+        compile_db_file.write(json.dumps(compile_db, indent=2))
+        compile_db_file.close()
+
+
+def GenerateCompileDBWithNinja(path, targets=["all"]):
+    """Generates a compile database using ninja.
+
+    Args:
+        path: The build directory to generate a compile database for.
+        targets: Additional targets to pass to ninja.
+
+    Returns:
+        List of the contents of the compile database.
+    """
+    ninja_path = shutil.which("ninja")
+    if ninja_path is None:
+        raise Exception("ninja not found in PATH")
+    json_compile_db = subprocess.check_output(
+        [ninja_path, "-C", path]
+        + targets
+        + ["-t", "compdb", "cc", "cxx", "objc", "objcxx"]
+    )
+    return json.loads(json_compile_db)
 
 
 def PerformBuild(data, configurations, params):

--- a/pylib/gyp/generator/ninja_test.py
+++ b/pylib/gyp/generator/ninja_test.py
@@ -6,6 +6,7 @@
 
 """ Unit tests for the ninja.py file. """
 
+import os
 import sys
 import unittest
 
@@ -49,6 +50,16 @@ class TestPrefixesAndSuffixes(unittest.TestCase):
         self.assertTrue(
             writer.ComputeOutputFileName(spec, "static_library").endswith(".a")
         )
+
+    def test_GenerateCompileDBWithNinja(self):
+        this_dir = os.path.abspath(os.path.dirname(__file__))
+        build_dir = os.path.normpath(os.path.join(this_dir, "../../../data/ninja"))
+        compile_db = ninja.GenerateCompileDBWithNinja(build_dir)
+        self.assertEqual(len(compile_db), 1)
+        self.assertEqual(compile_db[0]["directory"], build_dir)
+        self.assertEqual(compile_db[0]["command"], "cc my.in my.out")
+        self.assertEqual(compile_db[0]["file"], "my.in")
+        self.assertEqual(compile_db[0]["output"], "my.out")
 
 
 if __name__ == "__main__":

--- a/pylib/gyp/generator/ninja_test.py
+++ b/pylib/gyp/generator/ninja_test.py
@@ -6,7 +6,7 @@
 
 """ Unit tests for the ninja.py file. """
 
-import os
+from pathlib import Path
 import sys
 import unittest
 
@@ -52,14 +52,15 @@ class TestPrefixesAndSuffixes(unittest.TestCase):
         )
 
     def test_GenerateCompileDBWithNinja(self):
-        this_dir = os.path.abspath(os.path.dirname(__file__))
-        build_dir = os.path.normpath(os.path.join(this_dir, "../../../data/ninja"))
+        build_dir = (
+            Path(__file__).resolve().parent.parent.parent.parent / "data" / "ninja"
+        )
         compile_db = ninja.GenerateCompileDBWithNinja(build_dir)
-        self.assertEqual(len(compile_db), 1)
-        self.assertEqual(compile_db[0]["directory"], build_dir)
-        self.assertEqual(compile_db[0]["command"], "cc my.in my.out")
-        self.assertEqual(compile_db[0]["file"], "my.in")
-        self.assertEqual(compile_db[0]["output"], "my.out")
+        assert len(compile_db) == 1
+        assert compile_db[0]["directory"] == str(build_dir)
+        assert compile_db[0]["command"] == "cc my.in my.out"
+        assert compile_db[0]["file"] == "my.in"
+        assert compile_db[0]["output"] == "my.out"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
ninja supports generating `compile_commands.json` from ninja files. The generated `compile_commands.json` resolves the generated product path as well, which is not supported in the [`gyp.generator.compile_commands_json`](https://github.com/nodejs/gyp-next/blob/main/pylib/gyp/generator/compile_commands_json.py#L70).

To generate `compile_commands.json` with ninja, define generator flag `-Gcompile_commands` when running gyp.