### PR TITLE
chore: remove component in release tags and set release sha

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,8 @@
         ".": {
           "release-type": "python",
           "package-name": "gyp-next",
-          "bump-minor-pre-major": true
+          "bump-minor-pre-major": true,
+          "include-component-in-tag": false
         }
     }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,4 +1,5 @@
 {
+    "last-release-sha": "78756421b0d7bb335992a9c7d26ba3cc8b619708",
     "packages": {
         ".": {
           "release-type": "python",


### PR DESCRIPTION
This sets `last-release-sha` to 78756421b0d7bb335992a9c7d26ba3cc8b619708 which is the commit releasing `0.16.2`. This config can be removed anytime in the future after the next release PR is merged.

This also sets `"include-component-in-tag": false` which should make release tags match the old pattern of only including the version prefixed with `v`.

Refs: #232