### PR TITLE
Fix compile_commands.json for MSVC

### DIFF
--- a/pylib/gyp/generator/compile_commands_json.py
+++ b/pylib/gyp/generator/compile_commands_json.py
@@ -109,7 +109,7 @@ def GenerateOutput(target_list, target_dicts, data, params):
         AddCommandsForTarget(cwd, target, params, per_config_commands)
 
     try:
-        # generator_output can be `None`, which means the current working directory
+        # generator_output can be `None` on Windows machines
         output_dir = params["options"].generator_output or os.getcwd()
     except (AttributeError, KeyError):
         output_dir = params["generator_flags"].get("output_dir", "out")

--- a/pylib/gyp/generator/compile_commands_json.py
+++ b/pylib/gyp/generator/compile_commands_json.py
@@ -109,7 +109,7 @@ def GenerateOutput(target_list, target_dicts, data, params):
         AddCommandsForTarget(cwd, target, params, per_config_commands)
 
     try:
-        output_dir = params["options"].generator_output
+        output_dir = params["options"].generator_output or os.getcwd()
     except (AttributeError, KeyError):
         output_dir = params["generator_flags"].get("output_dir", "out")
     for configuration_name, commands in per_config_commands.items():

--- a/pylib/gyp/generator/compile_commands_json.py
+++ b/pylib/gyp/generator/compile_commands_json.py
@@ -109,6 +109,7 @@ def GenerateOutput(target_list, target_dicts, data, params):
         AddCommandsForTarget(cwd, target, params, per_config_commands)
 
     try:
+        # generator_output can be `None`, which means the current working directory
         output_dir = params["options"].generator_output or os.getcwd()
     except (AttributeError, KeyError):
         output_dir = params["generator_flags"].get("output_dir", "out")


### PR DESCRIPTION
`generator_output` is `None` when trying to use that in Node.js via `vcbuild.bat`