### PR TITLE
Fix compile_commands.json output location when generator_output is None

### DIFF
--- a/pylib/gyp/generator/compile_commands_json.py
+++ b/pylib/gyp/generator/compile_commands_json.py
@@ -112,8 +112,8 @@ def GenerateOutput(target_list, target_dicts, data, params):
     try:
         # generator_output can be `None` on Windows machines, or even not
         # defined in other cases
-        output_dir = params["options"].generator_output
-    except (AttributeError, KeyError):
+        output_dir = params.get("options").generator_output
+    except AttributeError:
         pass
     output_dir = output_dir or params["generator_flags"].get("output_dir", "out")
     for configuration_name, commands in per_config_commands.items():

--- a/pylib/gyp/generator/compile_commands_json.py
+++ b/pylib/gyp/generator/compile_commands_json.py
@@ -108,10 +108,13 @@ def GenerateOutput(target_list, target_dicts, data, params):
         cwd = os.path.dirname(build_file)
         AddCommandsForTarget(cwd, target, params, per_config_commands)
 
+    output_dir = None
     try:
-        # generator_output can be `None` on Windows machines
-        output_dir = params["options"].generator_output or os.getcwd()
+        # generator_output can be `None` on Windows machines, or even not defined in other cases
+        output_dir = params["options"].generator_output
     except (AttributeError, KeyError):
+        pass
+    if output_dir is None:
         output_dir = params["generator_flags"].get("output_dir", "out")
     for configuration_name, commands in per_config_commands.items():
         filename = os.path.join(output_dir, configuration_name, "compile_commands.json")

--- a/pylib/gyp/generator/compile_commands_json.py
+++ b/pylib/gyp/generator/compile_commands_json.py
@@ -110,7 +110,8 @@ def GenerateOutput(target_list, target_dicts, data, params):
 
     output_dir = None
     try:
-        # generator_output can be `None` on Windows machines, or even not defined in other cases
+        # generator_output can be `None` on Windows machines, or even not
+        # defined in other cases
         output_dir = params["options"].generator_output
     except (AttributeError, KeyError):
         pass

--- a/pylib/gyp/generator/compile_commands_json.py
+++ b/pylib/gyp/generator/compile_commands_json.py
@@ -115,8 +115,7 @@ def GenerateOutput(target_list, target_dicts, data, params):
         output_dir = params["options"].generator_output
     except (AttributeError, KeyError):
         pass
-    if output_dir is None:
-        output_dir = params["generator_flags"].get("output_dir", "out")
+    output_dir = output_dir or params["generator_flags"].get("output_dir", "out")
     for configuration_name, commands in per_config_commands.items():
         filename = os.path.join(output_dir, configuration_name, "compile_commands.json")
         gyp.common.EnsureDirExists(filename)


### PR DESCRIPTION
Followup to #238 after discussion at https://github.com/nodejs/node/pull/52279#discussion_r1546658089

cc @anonrig @cclauss 