### PR TITLE
fix: failed to detect flavor if compiler path include white spaces

### DIFF
--- a/pylib/gyp/common.py
+++ b/pylib/gyp/common.py
@@ -468,7 +468,6 @@ def GetCrossCompilerPredefines():  # -> dict
         if (line or "").startswith("#define "):
             _, key, *value = line.split(" ")
             defines[key] = " ".join(value)
-            continue
     return defines
 
 def GetFlavorByPlatform():

--- a/pylib/gyp/common.py
+++ b/pylib/gyp/common.py
@@ -465,10 +465,9 @@ def GetCrossCompilerPredefines():  # -> dict
     defines = {}
     lines = stdout.decode("utf-8").replace("\r\n", "\n").split("\n")
     for line in lines:
-        if not line:
+        if not line or not line.startswith("#define "):
             continue
-        define_directive, key, *value = line.split(" ")
-        assert define_directive == "#define"
+        _, key, *value = line.split(" ")
         defines[key] = " ".join(value)
     return defines
 

--- a/pylib/gyp/common.py
+++ b/pylib/gyp/common.py
@@ -426,10 +426,11 @@ def EnsureDirExists(path):
 def GetCrossCompilerPredefines():  # -> dict
     cmd = []
 
-    # shlex.split() will eat '\' in posix mode
-    # but setting posix=False will preserve extra '"' cause CreateProcess fail on Windows
+    # shlex.split() will eat '\' in posix mode, but
+    # setting posix=False will preserve extra '"' cause CreateProcess fail on Windows
     # this makes '\' in %CC_target% and %CFLAGS% work
-    replace_sep = lambda s : s.replace("\\", "/") if sys.platform == "win32" else s
+    def replace_sep(s):
+        return s.replace("\\", "/") if sys.platform == "win32" else s
 
     if CC := os.environ.get("CC_target") or os.environ.get("CC"):
         cmd += shlex.split(replace_sep(CC))

--- a/pylib/gyp/common.py
+++ b/pylib/gyp/common.py
@@ -451,7 +451,7 @@ def GetCrossCompilerPredefines():  # -> dict
             out = subprocess.Popen(
                 real_cmd,
                 shell=True,
-                stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE
             )
             stdout, stderr = out.communicate()
         finally:
@@ -462,7 +462,7 @@ def GetCrossCompilerPredefines():  # -> dict
         out = subprocess.Popen(
             real_cmd,
             shell=False,
-            stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
         stdout, stderr = out.communicate()
 

--- a/pylib/gyp/common.py
+++ b/pylib/gyp/common.py
@@ -9,6 +9,7 @@ import re
 import tempfile
 import sys
 import subprocess
+import shlex
 
 from collections.abc import MutableSet
 
@@ -425,13 +426,13 @@ def EnsureDirExists(path):
 def GetCrossCompilerPredefines():  # -> dict
     cmd = []
     if CC := os.environ.get("CC_target") or os.environ.get("CC"):
-        cmd += CC.split(" ")
+        cmd += shlex.split(CC)
         if CFLAGS := os.environ.get("CFLAGS"):
-            cmd += CFLAGS.split(" ")
+            cmd += shlex.split(CFLAGS)
     elif CXX := os.environ.get("CXX_target") or os.environ.get("CXX"):
-        cmd += CXX.split(" ")
+        cmd += shlex.split(CXX)
         if CXXFLAGS := os.environ.get("CXXFLAGS"):
-            cmd += CXXFLAGS.split(" ")
+            cmd += shlex.split(CXXFLAGS)
     else:
         return {}
 

--- a/pylib/gyp/common.py
+++ b/pylib/gyp/common.py
@@ -430,7 +430,7 @@ def GetCrossCompilerPredefines():  # -> dict
     # setting posix=False will preserve extra '"' cause CreateProcess fail on Windows
     # this makes '\' in %CC_target% and %CFLAGS% work
     def replace_sep(s):
-        return s.replace("\\", "/") if sys.platform == "win32" else s
+        return s.replace(os.sep, "/") if os.sep != "/" else s
 
     if CC := os.environ.get("CC_target") or os.environ.get("CC"):
         cmd += shlex.split(replace_sep(CC))

--- a/pylib/gyp/common.py
+++ b/pylib/gyp/common.py
@@ -465,10 +465,10 @@ def GetCrossCompilerPredefines():  # -> dict
     defines = {}
     lines = stdout.decode("utf-8").replace("\r\n", "\n").split("\n")
     for line in lines:
-        if not line or not line.startswith("#define "):
+        if (line or "").startswith("#define "):
+            _, key, *value = line.split(" ")
+            defines[key] = " ".join(value)
             continue
-        _, key, *value = line.split(" ")
-        defines[key] = " ".join(value)
     return defines
 
 def GetFlavorByPlatform():

--- a/pylib/gyp/common.py
+++ b/pylib/gyp/common.py
@@ -448,26 +448,20 @@ def GetCrossCompilerPredefines():  # -> dict
         real_cmd = [*cmd, "-dM", "-E", "-x", "c", input]
         try:
             os.close(fd)
-            out = subprocess.Popen(
-                real_cmd,
-                shell=True,
-                stdout=subprocess.PIPE, stderr=subprocess.PIPE
-            )
-            stdout, stderr = out.communicate()
+            stdout = subprocess.run(
+                real_cmd, shell=True,
+                capture_output=True, check=True
+            ).stdout
         finally:
             os.unlink(input)
     else:
         input = "/dev/null"
         real_cmd = [*cmd, "-dM", "-E", "-x", "c", input]
-        out = subprocess.Popen(
-            real_cmd,
-            shell=False,
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE
-        )
-        stdout, stderr = out.communicate()
+        stdout = subprocess.run(
+            real_cmd, shell=False,
+            capture_output=True, check=True
+        ).stdout
 
-    if out.returncode != 0:
-        raise subprocess.CalledProcessError(out.returncode, real_cmd, stdout, stderr)
     defines = {}
     lines = stdout.decode("utf-8").replace("\r\n", "\n").split("\n")
     for line in lines:

--- a/pylib/gyp/common_test.py
+++ b/pylib/gyp/common_test.py
@@ -111,7 +111,7 @@ class TestGetFlavor(unittest.TestCase):
                             "-dM", "-E", "-x", "c", expected_input
                         ],
                         shell=sys.platform == "win32",
-                        stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+                        stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                 return [defines, flavor]
 
         [defines1, _] = mock_run({}, "", [])

--- a/pylib/gyp/common_test.py
+++ b/pylib/gyp/common_test.py
@@ -117,7 +117,7 @@ class TestGetFlavor(unittest.TestCase):
             ["/opt/wasi-sdk/bin/clang"]
         )
         assert { "__wasm__": "1", "__wasi__": "1" } == defines2
-        assert "wasi" == flavor2
+        assert flavor2 == "wasi"
 
         [defines3, flavor3] = mock_run(
             { "CC_target": "/opt/wasi-sdk/bin/clang --target=wasm32" },
@@ -125,7 +125,7 @@ class TestGetFlavor(unittest.TestCase):
             ["/opt/wasi-sdk/bin/clang", "--target=wasm32"]
         )
         assert { "__wasm__": "1" } == defines3
-        assert "wasm" == flavor3
+        assert flavor3 == "wasm"
 
         [defines4, flavor4] = mock_run(
             { "CC_target": "/emsdk/upstream/emscripten/emcc" },
@@ -133,7 +133,7 @@ class TestGetFlavor(unittest.TestCase):
             ["/emsdk/upstream/emscripten/emcc"]
         )
         assert { "__EMSCRIPTEN__": "1" } == defines4
-        assert "emscripten" == flavor4
+        assert flavor4 == "emscripten"
 
         # Test path which include white space
         [defines5, flavor5] = mock_run(
@@ -154,18 +154,18 @@ class TestGetFlavor(unittest.TestCase):
             "__wasi__": "1",
             "_REENTRANT": "1"
         } == defines5
-        assert "wasi" == flavor5
+        assert flavor5 == "wasi"
 
-        original_platform = os.sep
+        original_sep = os.sep
         os.sep = "\\"
         [defines6, flavor6] = mock_run(
             { "CC_target": "\"C:\\Program Files\\wasi-sdk\\clang.exe\"" },
             "#define __wasm__ 1\n#define __wasi__ 1\n",
             ["C:/Program Files/wasi-sdk/clang.exe"]
         )
-        os.sep = original_platform
+        os.sep = original_sep
         assert { "__wasm__": "1", "__wasi__": "1" } == defines6
-        assert "wasi" == flavor6
+        assert flavor6 == "wasi"
 
 if __name__ == "__main__":
     unittest.main()

--- a/pylib/gyp/common_test.py
+++ b/pylib/gyp/common_test.py
@@ -11,7 +11,6 @@ import unittest
 import sys
 import os
 import subprocess
-import shlex
 from unittest.mock import patch, MagicMock
 
 class TestTopologicallySorted(unittest.TestCase):

--- a/pylib/gyp/common_test.py
+++ b/pylib/gyp/common_test.py
@@ -25,10 +25,8 @@ class TestTopologicallySorted(unittest.TestCase):
 
         def GetEdge(node):
             return tuple(graph[node])
-
-        self.assertEqual(
-            gyp.common.TopologicallySorted(graph.keys(), GetEdge), ["a", "c", "d", "b"]
-        )
+        
+        assert gyp.common.TopologicallySorted(graph.keys(), GetEdge) == ["a", "c", "d", "b"]
 
     def test_Cycle(self):
         """Test that an exception is thrown on a cyclic graph."""
@@ -60,7 +58,7 @@ class TestGetFlavor(unittest.TestCase):
 
     def assertFlavor(self, expected, argument, param):
         sys.platform = argument
-        self.assertEqual(expected, gyp.common.GetFlavor(param))
+        assert expected == gyp.common.GetFlavor(param)
 
     def test_platform_default(self):
         self.assertFlavor("freebsd", "freebsd9", {})
@@ -115,31 +113,31 @@ class TestGetFlavor(unittest.TestCase):
                 return [defines, flavor]
 
         [defines1, _] = mock_run({}, "", [])
-        self.assertDictEqual({}, defines1)
+        assert {} == defines1
 
         [defines2, flavor2] = mock_run(
             { "CC_target": "/opt/wasi-sdk/bin/clang" },
             "#define __wasm__ 1\n#define __wasi__ 1\n",
             ["/opt/wasi-sdk/bin/clang"]
         )
-        self.assertDictEqual({ "__wasm__": "1", "__wasi__": "1" }, defines2)
-        self.assertEqual("wasi", flavor2)
+        assert { "__wasm__": "1", "__wasi__": "1" } == defines2
+        assert "wasi" == flavor2
 
         [defines3, flavor3] = mock_run(
             { "CC_target": "/opt/wasi-sdk/bin/clang --target=wasm32" },
             "#define __wasm__ 1\n",
             ["/opt/wasi-sdk/bin/clang", "--target=wasm32"]
         )
-        self.assertDictEqual({ "__wasm__": "1" }, defines3)
-        self.assertEqual("wasm", flavor3)
+        assert { "__wasm__": "1" } == defines3
+        assert "wasm" == flavor3
 
         [defines4, flavor4] = mock_run(
             { "CC_target": "/emsdk/upstream/emscripten/emcc" },
             "#define __EMSCRIPTEN__ 1\n",
             ["/emsdk/upstream/emscripten/emcc"]
         )
-        self.assertDictEqual({ "__EMSCRIPTEN__": "1" }, defines4)
-        self.assertEqual("emscripten", flavor4)
+        assert { "__EMSCRIPTEN__": "1" } == defines4
+        assert "emscripten" == flavor4
 
         # Test path which include white space
         [defines5, flavor5] = mock_run(
@@ -155,12 +153,12 @@ class TestGetFlavor(unittest.TestCase):
                 "-pthread"
             ]
         )
-        self.assertDictEqual({
+        assert {
             "__wasm__": "1",
             "__wasi__": "1",
             "_REENTRANT": "1"
-        }, defines5)
-        self.assertEqual("wasi", flavor5)
+        } == defines5
+        assert "wasi" == flavor5
 
         original_platform = os.sep
         os.sep = "\\"
@@ -170,8 +168,8 @@ class TestGetFlavor(unittest.TestCase):
             ["C:/Program Files/wasi-sdk/clang.exe"]
         )
         os.sep = original_platform
-        self.assertDictEqual({ "__wasm__": "1", "__wasi__": "1" }, defines6)
-        self.assertEqual("wasi", flavor6)
+        assert { "__wasm__": "1", "__wasi__": "1" } == defines6
+        assert "wasi" == flavor6
 
 if __name__ == "__main__":
     unittest.main()

--- a/pylib/gyp/common_test.py
+++ b/pylib/gyp/common_test.py
@@ -162,14 +162,14 @@ class TestGetFlavor(unittest.TestCase):
         }, defines5)
         self.assertEqual("wasi", flavor5)
 
-        original_platform = sys.platform
-        sys.platform = "win32"
+        original_platform = os.sep
+        os.sep = "\\"
         [defines6, flavor6] = mock_run(
             { "CC_target": "\"C:\\Program Files\\wasi-sdk\\clang.exe\"" },
             "#define __wasm__ 1\n#define __wasi__ 1\n",
             ["C:/Program Files/wasi-sdk/clang.exe"]
         )
-        sys.platform = original_platform
+        os.sep = original_platform
         self.assertDictEqual({ "__wasm__": "1", "__wasi__": "1" }, defines6)
         self.assertEqual("wasi", flavor6)
 


### PR DESCRIPTION
This PR is a follow-up optimization to #222.

In previous implementation of `GetCrossCompilerPredefines`, if `CC_target` include white space

`"/Users/Toyo Li/wasi-sdk/bin/clang"`

the cmd passed to `subprocess.Popen`  is incorrect:

`['"/Users/Toyo', 'Li/wasi-sdk/bin/clang"', ...]`

This PR fixed this issue, and will raise error if process exit code is not 0.