### PR TITLE
GitHub Actions test on macOS on ARM

### DIFF
--- a/.github/workflows/node-gyp.yml
+++ b/.github/workflows/node-gyp.yml
@@ -10,8 +10,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-latest, macos-14, ubuntu-latest, windows-latest]
         python: ["3.8", "3.10", "3.12"]
+        exclude:
+          - os: macos-14
+            python: "3.8"
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -17,6 +17,11 @@ jobs:
       matrix:
         os: [macos-latest, macos-14, ubuntu-latest] # , windows-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        exclude:
+          - os: macos-14
+            python-version: "3.8"
+          - os: macos-14
+            python-version: "3.9"
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        os: [macos-latest, ubuntu-latest] # , windows-latest]
+        os: [macos-latest, macos-14, ubuntu-latest] # , windows-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
GitHub Actions blog:
> Over the next 12 weeks, jobs using the `macos-latest` runner label will migrate from macOS 12 (Monterey) to macOS 14 (Sonoma).

https://github.blog/changelog/2024-04-01-macos-14-sonoma-is-generally-available-and-the-latest-macos-runner-image

* nodejs/node-gyp#3011