### PR TITLE
fix: support empty dictionary keys in input

### DIFF
--- a/pylib/gyp/input.py
+++ b/pylib/gyp/input.py
@@ -2536,6 +2536,8 @@ def ProcessListFiltersInDict(name, the_dict):
     lists = []
     del_lists = []
     for key, value in the_dict.items():
+        if key == "":
+            continue
         operation = key[-1]
         if operation not in {"!", "/"}:
             continue

--- a/pylib/gyp/input.py
+++ b/pylib/gyp/input.py
@@ -2536,7 +2536,7 @@ def ProcessListFiltersInDict(name, the_dict):
     lists = []
     del_lists = []
     for key, value in the_dict.items():
-        if key == "":
+        if not key:
             continue
         operation = key[-1]
         if operation not in {"!", "/"}:


### PR DESCRIPTION
Certain old keys in `msvs_settings` (like "LinkIncremental") are moved
to the top level when translated to `msbuild_settings`.
This change allows to set them when `msbuild_settings` are
authored directly.
