### PR TITLE
fix: declare packaging in package discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,4 +118,4 @@ max-statements = 286
 
 [tool.setuptools]
 package-dir = {"" = "pylib"}
-packages = ["gyp", "gyp.generator"]
+packages = ["gyp", "gyp.generator", "packaging"]


### PR DESCRIPTION
`packaging` needs to be declared in setuptools package discovery config.