### PR TITLE
chore: dependencies = setuptools for `gyp --version` on Python >= 3.12

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -41,3 +41,7 @@ jobs:
         run: pytest
       # - name: Run doctests with pytest
       #   run: pytest --doctest-modules
+      - name: Test CLI commands on a pipx install
+        run: |
+          pipx run --no-cache --spec ./ gyp --help
+          pipx run --no-cache --spec ./ gyp --version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ description = "A fork of the GYP build system for use in the Node.js projects"
 readme = "README.md"
 license = { file="LICENSE" }
 requires-python = ">=3.8"
-dependencies = ["packaging>=24.0"]
+dependencies = ["setuptools>=69.5.1"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Environment :: Console",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ description = "A fork of the GYP build system for use in the Node.js projects"
 readme = "README.md"
 license = { file="LICENSE" }
 requires-python = ">=3.8"
-dependencies = ["setuptools>=69.5.1"]
+dependencies = ["packaging>=24.0", "setuptools>=69.5.1"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Environment :: Console",


### PR DESCRIPTION
Fixes #259

On Python >= 3.12

% `pipx run --no-cache --spec git+https://github.com/nodejs/gyp-next.git gyp --help` was erroring with
> ModuleNotFoundError: No module named 'packaging'

% `pipx run --no-cache --spec git+https://github.com/nodejs/gyp-next.git gyp --version` is still erroring with
> ModuleNotFoundError: No module named 'pkg_resources'

`gyp --help` was fixed in gyp-next v0.18.0
`gyp --version` was not

Since ___both modules___ are included `setuptools` let's use that recommended fix.

---
Proof:
% `pipx install gyp-next`
% `gyp --version ` # Fails!
% `pipx inject gyp-next setuptools ` # This is the same action as this pull request.
% `gyp --version ` # Works as expected.
% `gyp --help ` # Works as expected.