### PR TITLE
fix(ci): add Python 3.13 pre-release to test matrix

### DIFF
--- a/.github/workflows/node-gyp.yml
+++ b/.github/workflows/node-gyp.yml
@@ -10,11 +10,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, macos-14, ubuntu-latest, windows-latest]
+        os: [macos-latest, ubuntu-latest, windows-latest]
         python: ["3.8", "3.10", "3.12", "3.13"]
-        exclude:
-          - os: macos-14
-            python: "3.8"
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/node-gyp.yml
+++ b/.github/workflows/node-gyp.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, macos-14, ubuntu-latest, windows-latest]
-        python: ["3.8", "3.10", "3.12"]
+        python: ["3.8", "3.10", "3.12", "3.13"]
         exclude:
           - os: macos-14
             python: "3.8"

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -16,7 +16,7 @@ jobs:
       max-parallel: 5
       matrix:
         os: [macos-latest, macos-14, ubuntu-latest] # , windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         exclude:
           - os: macos-14
             python-version: "3.8"

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -15,13 +15,8 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        os: [macos-latest, macos-14, ubuntu-latest] # , windows-latest]
+        os: [macos-latest, ubuntu-latest] # , windows-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
-        exclude:
-          - os: macos-14
-            python-version: "3.8"
-          - os: macos-14
-            python-version: "3.9"
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
Add Python 3.13 to the CI test matrix for gyp-next repo.

[Python 3.13 is in beta now](https://blog.python.org/2024/05/python-3130-beta-1-released.html), and will be stable soonish (October 2024).

This PR relates to #219. There was some enthusiasm there in a comment: https://github.com/nodejs/gyp-next/issues/219#issuecomment-2102537214 so I figured I'd open a PR for this real quick.

(Commentary: For what it's worth, gyp-next tests have been passing with Python 3.13 on my personal fork for some time now, even when Python 3.13 was still in alpha. But now it's in beta, so this should be a reasonable time to start testing against it in the official repo?)