### PR TITLE
chore: Run Node.js integration tests on pre-release Py3.13

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-13, macos-latest, ubuntu-latest, windows-latest]
-        python: ["3.8", "3.10", "3.12"]
+        python: ["3.8", "3.10", "3.12", "3.13"]
 
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
As recommended at:
* https://github.com/nodejs/gyp-next/pull/255/files#r1595576100