### PR TITLE
chore: fix XCConfigurationList assertion

### DIFF
--- a/.github/workflows/node-gyp.yml
+++ b/.github/workflows/node-gyp.yml
@@ -1,12 +1,11 @@
 name: node-gyp integration
 on:
   push:
-    branches: [ main ]
   pull_request:
-    branches: [ main ]
   workflow_dispatch:
+
 jobs:
-  integration:
+  node-gyp-integration:
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,13 +1,11 @@
 name: Node.js integration
 on:
   push:
-    branches: [ main ]
   pull_request:
-    branches: [ main ]
   workflow_dispatch:
 
 jobs:
-  integration:
+  nodejs-integration:
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -4,10 +4,9 @@
 name: Python_tests
 on:
   push:
-    branches: [ main ]
   pull_request:
-    branches: [ main ]
   workflow_dispatch:
+
 jobs:
   Python_tests:
     runs-on: ${{ matrix.os }}

--- a/pylib/gyp/xcodeproj_file.py
+++ b/pylib/gyp/xcodeproj_file.py
@@ -781,7 +781,7 @@ class XCObject:
             # Make sure the property conforms to the schema.
             (is_list, property_type, is_strong) = self._schema[property][0:3]
             if is_list:
-                if not isinstance(value.__class__, list):
+                if not isinstance(value, list):
                     raise TypeError(
                         property
                         + " of "


### PR DESCRIPTION
Fix tests. 

Weirdly, GitHub action didn't run for https://github.com/nodejs/gyp-next/pull/263 and it showed green to be merged. I enabled the following settings for the repo to avoid accidental merge if GitHub action was not triggered.

- Require status checks to pass before merging, and
- Require branches to be up to date before merging (the original PR needs to be updated with the main branch before merging so that we don't have to fixup again).
