### PR TITLE
ruff rule PLC0206 and RUF021

### DIFF
--- a/pylib/gyp/MSVSSettings.py
+++ b/pylib/gyp/MSVSSettings.py
@@ -171,7 +171,7 @@ class _Integer(_Type):
         int(value, self._msbuild_base)
 
     def ConvertToMSBuild(self, value):
-        msbuild_format = (self._msbuild_base == 10) and "%d" or "0x%04x"
+        msbuild_format = ((self._msbuild_base == 10) and "%d") or "0x%04x"
         return msbuild_format % int(value)
 
 

--- a/pylib/gyp/MSVSVersion.py
+++ b/pylib/gyp/MSVSVersion.py
@@ -69,7 +69,7 @@ class VisualStudioVersion:
 
     def ProjectExtension(self):
         """Returns the file extension for the project."""
-        return self.uses_vcxproj and ".vcxproj" or ".vcproj"
+        return (self.uses_vcxproj and ".vcxproj") or ".vcproj"
 
     def Path(self):
         """Returns the path to Visual Studio installation."""

--- a/pylib/gyp/__init__.py
+++ b/pylib/gyp/__init__.py
@@ -253,7 +253,7 @@ def RegenerateFlags(options):
     for name, metadata in options._regeneration_metadata.items():
         opt = metadata["opt"]
         value = getattr(options, name)
-        value_predicate = metadata["type"] == "path" and FixPath or Noop
+        value_predicate = (metadata["type"] == "path" and FixPath) or Noop
         action = metadata["action"]
         env_name = metadata["env_name"]
         if action == "append":

--- a/pylib/gyp/generator/make.py
+++ b/pylib/gyp/generator/make.py
@@ -788,7 +788,7 @@ class MakefileWriter:
         self.suffix_rules_objdir2 = {}
 
         # Generate suffix rules for all compilable extensions.
-        for ext in COMPILABLE_EXTENSIONS:
+        for ext, value in COMPILABLE_EXTENSIONS.items():
             # Suffix rules for source folder.
             self.suffix_rules_srcdir.update(
                 {
@@ -797,7 +797,7 @@ class MakefileWriter:
 $(obj).$(TOOLSET)/$(TARGET)/%%.o: $(srcdir)/%%%s FORCE_DO_CMD
 \t@$(call do_cmd,%s,1)
 """
-                        % (ext, COMPILABLE_EXTENSIONS[ext])
+                        % (ext, value)
                     )
                 }
             )
@@ -810,7 +810,7 @@ $(obj).$(TOOLSET)/$(TARGET)/%%.o: $(srcdir)/%%%s FORCE_DO_CMD
 $(obj).$(TOOLSET)/$(TARGET)/%%.o: $(obj).$(TOOLSET)/%%%s FORCE_DO_CMD
 \t@$(call do_cmd,%s,1)
 """
-                        % (ext, COMPILABLE_EXTENSIONS[ext])
+                        % (ext, value)
                     )
                 }
             )
@@ -821,7 +821,7 @@ $(obj).$(TOOLSET)/$(TARGET)/%%.o: $(obj).$(TOOLSET)/%%%s FORCE_DO_CMD
 $(obj).$(TOOLSET)/$(TARGET)/%%.o: $(obj)/%%%s FORCE_DO_CMD
 \t@$(call do_cmd,%s,1)
 """
-                        % (ext, COMPILABLE_EXTENSIONS[ext])
+                        % (ext, value)
                     )
                 }
             )
@@ -1779,13 +1779,13 @@ $(obj).$(TOOLSET)/$(TARGET)/%%.o: $(obj)/%%%s FORCE_DO_CMD
             # using ":=".
             self.WriteSortedXcodeEnv(self.output, self.GetSortedXcodePostbuildEnv())
 
-            for configname in target_postbuilds:
+            for configname, value in target_postbuilds.items():
                 self.WriteLn(
                     "%s: TARGET_POSTBUILDS_%s := %s"
                     % (
                         QuoteSpaces(self.output),
                         configname,
-                        gyp.common.EncodePOSIXShellList(target_postbuilds[configname]),
+                        gyp.common.EncodePOSIXShellList(value),
                     )
                 )
 

--- a/pylib/gyp/input.py
+++ b/pylib/gyp/input.py
@@ -2469,11 +2469,8 @@ def SetUpConfigurations(target, target_dict):
         merged_configurations[configuration] = new_configuration_dict
 
     # Put the new configurations back into the target dict as a configuration.
-    for configuration in merged_configurations:
-        target_dict["configurations"][configuration] = merged_configurations[
-            configuration
-        ]
-
+    for configuration, value in merged_configurations.items():
+        target_dict["configurations"][configuration] = value
     # Now drop all the abstract ones.
     configs = target_dict["configurations"]
     target_dict["configurations"] = {
@@ -3020,8 +3017,8 @@ def Load(
                     del target_dict[key]
         ProcessListFiltersInDict(target_name, tmp_dict)
         # Write the results back to |target_dict|.
-        for key in tmp_dict:
-            target_dict[key] = tmp_dict[key]
+        for key, value in tmp_dict.items():
+            target_dict[key] = value
 
     # Make sure every dependency appears at most once.
     RemoveDuplicateDependencies(targets)

--- a/pylib/gyp/xcode_emulation.py
+++ b/pylib/gyp/xcode_emulation.py
@@ -1127,8 +1127,8 @@ class XcodeSettings:
     be deployed to a device.  This should be run as the very last step of the
     build."""
         if not (
-            self.isIOS
-            and (self.spec["type"] == "executable" or self._IsXCTest())
+            (self.isIOS
+            and (self.spec["type"] == "executable" or self._IsXCTest()))
             or self.IsIosFramework()
         ):
             return []

--- a/pylib/gyp/xcodeproj_file.py
+++ b/pylib/gyp/xcodeproj_file.py
@@ -3017,10 +3017,10 @@ class PBXProject(XCContainerPortal):
         symroots = self._DefinedSymroots(target)
         for s in self._DefinedSymroots(target):
             if (
-                s is not None
-                and not self._IsUniqueSymrootForTarget(s)
-                or s is None
-                and not inherit_unique_symroot
+                (s is not None
+                and not self._IsUniqueSymrootForTarget(s))
+                or (s is None
+                and not inherit_unique_symroot)
             ):
                 return False
         return True if symroots else inherit_unique_symroot

--- a/tools/pretty_sln.py
+++ b/tools/pretty_sln.py
@@ -93,10 +93,10 @@ def ParseSolution(solution_file):
             continue
 
     # Change all dependencies clsid to name instead.
-    for project in dependencies:
+    for project, deps in dependencies.items():
         # For each dependencies in this project
         new_dep_array = []
-        for dep in dependencies[project]:
+        for dep in deps:
             # Look for the project name matching this cldis
             for project_info in projects:
                 if projects[project_info][1] == dep:

--- a/tools/pretty_vcproj.py
+++ b/tools/pretty_vcproj.py
@@ -118,8 +118,8 @@ def FixFilenames(filenames, current_directory):
     new_list = []
     for filename in filenames:
         if filename:
-            for key in REPLACEMENTS:
-                filename = filename.replace(key, REPLACEMENTS[key])
+            for key, value in REPLACEMENTS.items():
+                filename = filename.replace(key, value)
             os.chdir(current_directory)
             filename = filename.strip("\"' ")
             if filename.startswith("$"):


### PR DESCRIPTION
% [`ruff rule PLC0206`](https://docs.astral.sh/ruff/rules/dict-index-missing-items)
# dict-index-missing-items (PLC0206)

Derived from the **Pylint** linter.

## What it does
Checks for dictionary iterations that extract the dictionary value
via explicit indexing, instead of using `.items()`.

## Why is this bad?
Iterating over a dictionary with `.items()` is semantically clearer
and more efficient than extracting the value with the key.

## Example
```python
ORCHESTRA = {
    "violin": "strings",
    "oboe": "woodwind",
    "tuba": "brass",
    "gong": "percussion",
}

for instrument in ORCHESTRA:
    print(f"{instrument}: {ORCHESTRA[instrument]}")
```

Use instead:
```python
ORCHESTRA = {
    "violin": "strings",
    "oboe": "woodwind",
    "tuba": "brass",
    "gong": "percussion",
}

for instrument, section in ORCHESTRA.items():
    print(f"{instrument}: {section}")
```
---
% [`ruff rule RUF021`](https://docs.astral.sh/ruff/rules/parenthesize-chained-operators)
# parenthesize-chained-operators (RUF021)

Derived from the **Ruff-specific rules** linter.

Fix is always available.

## What it does
Checks for chained operators where adding parentheses could improve the
clarity of the code.

## Why is this bad?
`and` always binds more tightly than `or` when chaining the two together,
but this can be hard to remember (and sometimes surprising).
Adding parentheses in these situations can greatly improve code readability,
with no change to semantics or performance.

For example:
```python
a, b, c = 1, 0, 2
x = a or b and c

d, e, f = 0, 1, 2
y = d and e or f
```

Use instead:
```python
a, b, c = 1, 0, 2
x = a or (b and c)

d, e, f = 0, 1, 2
y = (d and e) or f
```
