### PR TITLE
feat: provide escaped version of `PRODUCT_DIR_ABS`

### DIFF
--- a/pylib/gyp/__init__.py
+++ b/pylib/gyp/__init__.py
@@ -4,7 +4,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-
+from __future__ import annotations
 import copy
 import gyp.input
 import argparse

--- a/pylib/gyp/__init__.py
+++ b/pylib/gyp/__init__.py
@@ -24,13 +24,14 @@ DEBUG_GENERAL = "general"
 DEBUG_VARIABLES = "variables"
 DEBUG_INCLUDES = "includes"
 
-def EscapeForCString(string):
+def EscapeForCString(string: bytes | str) -> str:
     if isinstance(string, str):
         string = string.encode(encoding='utf8')
 
-    result = ''
+    backslash_or_double_quote = {ord('\\'), ord('"')}
+    result = []
     for char in string:
-        if not (32 <= char < 127) or char in (ord('\\'), ord('"')):
+        if char in backslash_or_double_quote or not 32 <= char < 127:
             result += '\\%03o' % char
         else:
             result += chr(char)


### PR DESCRIPTION
Since Node.js uses this in a C string, we should provide a version that escapes it as a C string.

Needed by: https://github.com/nodejs/node/pull/56111