### PR TITLE
Make sure that `INCS_*` vars are properly escaped

### DIFF
--- a/pylib/gyp/generator/make.py
+++ b/pylib/gyp/generator/make.py
@@ -1430,7 +1430,7 @@ $(obj).$(TOOLSET)/$(TARGET)/%%.o: $(obj)/%%%s FORCE_DO_CMD
                 self.WriteList(cflags_objcc, "CFLAGS_OBJCC_%s" % configname)
             includes = config.get("include_dirs")
             if includes:
-                includes = [Sourceify(self.Absolutify(i)) for i in includes]
+                includes = [SourceifyAndQuoteSpaces(self.Absolutify(i)) for i in includes]
             self.WriteList(includes, "INCS_%s" % configname, prefix="-I")
 
         compilable = list(filter(Compilable, sources))


### PR DESCRIPTION
The main motivation behind this pull request is to make gyp-next do the right thing, even if the path to the project that you’re building contains spaces. See the commit message for details.

## How to test this pull request

1. Make sure that you have all of the prerequisites for [building Node.js with Ninja](https://github.com/nodejs/node/blob/0dbbabab9538c384a24d03dfc7ba4a7ea72d54f2/doc/contributing/building-node-with-ninja.md). (I’ve been able to put Node.js into a directory that contains spaces and build it with Ninja. I haven’t been able to do the same without Ninja yet.)

1. Make sure that you have [Wget](https://www.gnu.org/software/wget) installed.

1. Make sure that you have a clone of [the `node` repository](https://github.com/nodejs/node), and that the path to the clone of your Node.js repo contains spaces.

1. Change directory into your `node` repository.

1. Make sure that you are on the `node` repository’s `main` branch by running this command:

    ```
    git switch main
    ```

1. Try to build and test Node.js by running these commands:

    ```
    ./configure --debug --ninja
    make
    make test-only
    ```

    The final `make test-only` command will fail to build.

1. Download this pull request as a patch by running this command:

    ```
    wget https://patch-diff.githubusercontent.com/raw/nodejs/gyp-next/pull/280.patch
    ```

1. Apply this patch to the vendored dependency that’s in the `node` repo by running this command:

    ```
    git am --directory=deps/npm/node_modules/node-gyp/gyp 280.patch
    ```

1. Delete the patch file by running this command:

    ```
    rm 280.patch
    ```

1. Try to build and test Node.js by running these commands:

    ```
    ./configure --debug --ninja
    make
    make test-only
    ```

    At this point, the final `make test-only` command will successfully build, but (for me at least) one or more of the actual tests will fail once it’s run.

There’s almost certainly a better way to test out this pull request, but this is the best that I can come up with given the fact that I don’t really know anything about Node.js or gyp-next. If anyone can come up with a better or easier way to test out this pull request, then that would be helpful.