### PR TITLE
Test on GitHub Actions `windows-2025` image

### DIFF
--- a/.github/workflows/node-gyp.yml
+++ b/.github/workflows/node-gyp.yml
@@ -10,8 +10,15 @@ jobs:
       fail-fast: false
       matrix:
         node-version: ["22"]
-        os: [macos-13, macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-latest, ubuntu-latest, windows-latest]
         python-version: ["3.9", "3.11", "3.13"]
+        include:
+          - node-version: "22"
+            os: macos-13
+            python-version: "3.13"
+          - node-version: "22"
+            os: windows-2025
+            python-version: "3.13"
     runs-on: ${{ matrix.os }}
     steps:
       - name: Clone gyp-next
@@ -47,7 +54,6 @@ jobs:
           cp -r gyp-next node-gyp/gyp
       - name: Run tests (macOS or Linux)
         if: runner.os != 'Windows'
-        shell: bash
         run: |
           cd node-gyp
           npm test --python="${pythonLocation}/python"

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,8 +9,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-latest, ubuntu-latest, windows-latest]
         python: ["3.9", "3.11", "3.13"]
+        include:
+          - os: macos-13
+            python-version: "3.13"
+          - os: windows-2025
+            python-version: "3.13"
 
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
https://learn.microsoft.com/en-us/windows-server/get-started/windows-server-release-info https://learn.microsoft.com/en-us/windows-server/get-started/whats-new-windows-server-2025
* actions/runner-images#11228
* nodejs/node-gyp#3116

---
All Windows tests seem to pass.  Interesting that `windows-2025` runs the `node-gyp integration` tests more than twice as fast as `windows-latest`.  https://github.com/nodejs/gyp-next/actions/runs/12645554916/usage