### PR TITLE
fix: Ensure Consistent Order of build_files in WriteAutoRegenerationRule

### DIFF
--- a/pylib/gyp/generator/make.py
+++ b/pylib/gyp/generator/make.py
@@ -2381,7 +2381,7 @@ def WriteAutoRegenerationRule(params, root_makefile, makefile_name, build_files)
         % {
             "makefile_name": makefile_name,
             "deps": replace_sep(
-                " ".join(SourceifyAndQuoteSpaces(bf) for bf in build_files)
+                " ".join(sorted(SourceifyAndQuoteSpaces(bf) for bf in build_files))
             ),
             "cmd": replace_sep(gyp.common.EncodePOSIXShellList(
                 [gyp_binary, "-fmake"] + gyp.RegenerateFlags(options) + build_files_args


### PR DESCRIPTION
Related to https://github.com/nodejs/node-gyp/pull/3062. Thank @ben-zalekta-lmnd

This PR addresses an issue with the WriteAutoRegenerationRule function in node-gyp, where the build_files set was passed without sorting, leading to an inconsistent order of dependencies in the generated Makefile.

Changes:

Wrapped the build_files set in the sorted() function before it is processed in WriteAutoRegenerationRule. This ensures that the order of files is consistent across all runs, preventing issues in CI environments that rely on file hash comparisons.
Impact:
This change stabilizes the output of the Makefile generation process, resolving the issue of inconsistent file order and reducing false positives in CI checks.