### PR TITLE
fix: ignore failure of `GetCompilerPredefines`

### DIFF
--- a/pylib/gyp/common.py
+++ b/pylib/gyp/common.py
@@ -421,8 +421,9 @@ def EnsureDirExists(path):
     except OSError:
         pass
 
-def GetCrossCompilerPredefines():  # -> dict
+def GetCompilerPredefines():  # -> dict
     cmd = []
+    defines = {}
 
     # shlex.split() will eat '\' in posix mode, but
     # setting posix=False will preserve extra '"' cause CreateProcess fail on Windows
@@ -439,7 +440,7 @@ def GetCrossCompilerPredefines():  # -> dict
         if CXXFLAGS := os.environ.get("CXXFLAGS"):
             cmd += shlex.split(replace_sep(CXXFLAGS))
     else:
-        return {}
+        return defines
 
     if sys.platform == "win32":
         fd, input = tempfile.mkstemp(suffix=".c")
@@ -450,17 +451,33 @@ def GetCrossCompilerPredefines():  # -> dict
                 real_cmd, shell=True,
                 capture_output=True, check=True
             ).stdout
+        except subprocess.CalledProcessError as e:
+            print(
+                "Warning: failed to get compiler predefines\n"
+                "cmd: %s\n"
+                "status: %d" % (e.cmd, e.returncode),
+                file=sys.stderr
+            )
+            return defines
         finally:
             os.unlink(input)
     else:
         input = "/dev/null"
         real_cmd = [*cmd, "-dM", "-E", "-x", "c", input]
-        stdout = subprocess.run(
-            real_cmd, shell=False,
-            capture_output=True, check=True
-        ).stdout
+        try:
+            stdout = subprocess.run(
+                real_cmd, shell=False,
+                capture_output=True, check=True
+            ).stdout
+        except subprocess.CalledProcessError as e:
+            print(
+                "Warning: failed to get compiler predefines\n"
+                "cmd: %s\n"
+                "status: %d" % (e.cmd, e.returncode),
+                file=sys.stderr
+            )
+            return defines
 
-    defines = {}
     lines = stdout.decode("utf-8").replace("\r\n", "\n").split("\n")
     for line in lines:
         if (line or "").startswith("#define "):
@@ -499,7 +516,7 @@ def GetFlavor(params):
     if "flavor" in params:
         return params["flavor"]
 
-    defines = GetCrossCompilerPredefines()
+    defines = GetCompilerPredefines()
     if "__EMSCRIPTEN__" in defines:
         return "emscripten"
     if "__wasm__" in defines:


### PR DESCRIPTION
fixes https://github.com/nodejs/gyp-next/issues/294
fixes https://github.com/nodejs/node-gyp/issues/3164