### PR TITLE
GitHub Actions: Add ubuntu-24.04-arm and windows-11-arm

### DIFF
--- a/.github/workflows/node-gyp.yml
+++ b/.github/workflows/node-gyp.yml
@@ -14,10 +14,13 @@ jobs:
         python-version: ["3.9", "3.11", "3.13"]
         include:
           - node-version: "22"
-            os: macos-13
+            os: macos-13  # macOS on Intel
             python-version: "3.13"
           - node-version: "22"
-            os: windows-2025
+            os: ubuntu-24.04-arm  # Ubuntu on ARM
+            python-version: "3.13"
+          - node-version: "22"
+            os: windows-11-arm  # Windows on ARM
             python-version: "3.13"
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -12,9 +12,11 @@ jobs:
         os: [macos-latest, ubuntu-latest, windows-latest]
         python: ["3.9", "3.11", "3.13"]
         include:
-          - os: macos-13
+          - os: macos-13  # macOS on Intel
             python-version: "3.13"
-          - os: windows-2025
+          - os: ubuntu-24.04-arm  # Ubuntu on ARM
+            python-version: "3.13"
+          - os: windows-11-arm  # Windows on ARM
             python-version: "3.13"
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories

Remove windows-2025 because we haven't seen anything new with that.