### PR TITLE
fix: Python lint import-outside-top-level ruff rule PLC0415

### DIFF
--- a/pylib/gyp/MSVSVersion.py
+++ b/pylib/gyp/MSVSVersion.py
@@ -219,7 +219,7 @@ def _RegistryGetValueUsingWinReg(key, value):
     contents of the registry key's value, or None on failure.  Throws
     ImportError if winreg is unavailable.
   """
-    from winreg import HKEY_LOCAL_MACHINE, OpenKey, QueryValueEx
+    from winreg import HKEY_LOCAL_MACHINE, OpenKey, QueryValueEx  # noqa: PLC0415
     try:
         root, subkey = key.split("\\", 1)
         assert root == "HKLM"  # Only need HKLM for now.

--- a/pylib/gyp/__init__.py
+++ b/pylib/gyp/__init__.py
@@ -489,7 +489,7 @@ def gyp_main(args):
 
     options, build_files_arg = parser.parse_args(args)
     if options.version:
-        import pkg_resources
+        import pkg_resources  # noqa: PLC0415
         print(f"v{pkg_resources.get_distribution('gyp-next').version}")
         return 0
     build_files = build_files_arg

--- a/pylib/gyp/common.py
+++ b/pylib/gyp/common.py
@@ -583,7 +583,8 @@ def uniquer(seq, idfun=lambda x: x):
 
 
 # Based on http://code.activestate.com/recipes/576694/.
-class OrderedSet(MutableSet):
+class OrderedSet(MutableSet):  # noqa: PLW1641
+    # TODO (cclauss): Fix eq-without-hash ruff rule PLW1641
     def __init__(self, iterable=None):
         self.end = end = []
         end += [None, end, end]  # sentinel node for doubly linked list

--- a/pylib/gyp/generator/make.py
+++ b/pylib/gyp/generator/make.py
@@ -78,7 +78,7 @@ def CalculateVariables(default_variables, params):
 
         # Copy additional generator configuration data from Xcode, which is shared
         # by the Mac Make generator.
-        import gyp.generator.xcode as xcode_generator
+        import gyp.generator.xcode as xcode_generator  # noqa: PLC0415
 
         global generator_additional_non_configuration_keys
         generator_additional_non_configuration_keys = getattr(

--- a/pylib/gyp/generator/ninja.py
+++ b/pylib/gyp/generator/ninja.py
@@ -5,6 +5,7 @@
 
 import collections
 import copy
+import ctypes
 import hashlib
 import json
 import multiprocessing
@@ -1993,7 +1994,7 @@ def CalculateVariables(default_variables, params):
 
         # Copy additional generator configuration data from Xcode, which is shared
         # by the Mac Ninja generator.
-        import gyp.generator.xcode as xcode_generator
+        import gyp.generator.xcode as xcode_generator  # noqa: PLC0415
 
         generator_additional_non_configuration_keys = getattr(
             xcode_generator, "generator_additional_non_configuration_keys", []
@@ -2016,7 +2017,7 @@ def CalculateVariables(default_variables, params):
 
         # Copy additional generator configuration data from VS, which is shared
         # by the Windows Ninja generator.
-        import gyp.generator.msvs as msvs_generator
+        import gyp.generator.msvs as msvs_generator  # noqa: PLC0415
 
         generator_additional_non_configuration_keys = getattr(
             msvs_generator, "generator_additional_non_configuration_keys", []
@@ -2084,8 +2085,6 @@ def GetDefaultConcurrentLinks():
         return pool_size
 
     if sys.platform in ("win32", "cygwin"):
-        import ctypes
-
         class MEMORYSTATUSEX(ctypes.Structure):
             _fields_ = [
                 ("dwLength", ctypes.c_ulong),

--- a/pylib/gyp/mac_tool.py
+++ b/pylib/gyp/mac_tool.py
@@ -141,7 +141,7 @@ class MacTool:
         #     CFPropertyListCreateFromXMLData(): Old-style plist parser: missing
         #     semicolon in dictionary.
         # on invalid files. Do the same kind of validation.
-        import CoreFoundation
+        import CoreFoundation  # noqa: PLC0415
 
         with open(source, "rb") as in_file:
             s = in_file.read()

--- a/test_gyp.py
+++ b/test_gyp.py
@@ -148,13 +148,13 @@ def print_configuration_info():
     print("Test configuration:")
     if sys.platform == "darwin":
         sys.path.append(os.path.abspath("test/lib"))
-        import TestMac
+        import TestMac  # noqa: PLC0415
 
         print(f"  Mac {platform.mac_ver()[0]} {platform.mac_ver()[2]}")
         print(f"  Xcode {TestMac.Xcode.Version()}")
     elif sys.platform == "win32":
         sys.path.append(os.path.abspath("pylib"))
-        import gyp.MSVSVersion
+        import gyp.MSVSVersion  # noqa: PLC0415
 
         print("  Win %s %s\n" % platform.win32_ver()[0:2])
         print("  MSVS %s" % gyp.MSVSVersion.SelectVisualStudioVersion().Description())


### PR DESCRIPTION
Like node-gyp:
* nodejs/node-gyp#3171