### PR TITLE
fix: compilation failure on the OpenHarmony platform

### DIFF
--- a/pylib/gyp/generator/make.py
+++ b/pylib/gyp/generator/make.py
@@ -1880,7 +1880,7 @@ $(obj).$(TOOLSET)/$(TARGET)/%%.o: $(obj)/%%%s FORCE_DO_CMD
                 self.flavor not in ("mac", "openbsd", "netbsd", "win")
                 and not self.is_standalone_static_library
             ):
-                if self.flavor in ("linux", "android"):
+                if self.flavor in ("linux", "android", "openharmony"):
                     self.WriteMakeRule(
                         [self.output_binary],
                         link_deps,
@@ -1894,7 +1894,7 @@ $(obj).$(TOOLSET)/$(TARGET)/%%.o: $(obj)/%%%s FORCE_DO_CMD
                         part_of_all,
                         postbuilds=postbuilds,
                     )
-            elif self.flavor in ("linux", "android"):
+            elif self.flavor in ("linux", "android", "openharmony"):
                 self.WriteMakeRule(
                     [self.output_binary],
                     link_deps,


### PR DESCRIPTION
Node.js currently experimentally supports the OpenHarmony platform, and we can cross-compile Node.js for the OpenHarmony using the ohos-sdk.

However, the PR [#59234](https://github.com/nodejs/node/pull/59234) from a few days ago caused the compilation failure on the OpenHarmony platform.

The log is as follows:
```
make[1]: printf: Argument list too long
make[1]: *** [deps/openssl/openssl.target.mk:1337: /root/auto_sync/output/2025-07-30/node-ohos/out/Release/obj.target/deps/openssl/libopenssl.a] Error 127
make[1]: *** Waiting for unfinished jobs....
rm cc0ae594b47059c6d4f3fed11027e19cf65ff752.intermediate 5375dc893f377c01b6180c592cc7d13f21f1b93a.intermediate
make: *** [Makefile:135: node] Error 2
```

The reason for this failure is that the increase in the number of OpenSSL files has led to an increase in the length of the arguments for `printf`, causing the error 'Argument list too long'.

To fix this compilation failure, I replaced `WriteDoCmd` with `WriteMakeRule` to resolve the issue of the argument length limit.