### PR TITLE
fix: make xcode_emulation handle `xcodebuild` not in the `PATH`

### DIFF
--- a/pylib/gyp/xcode_emulation.py
+++ b/pylib/gyp/xcode_emulation.py
@@ -521,7 +521,7 @@ class XcodeSettings:
         # most sensible route and should still do the right thing.
         try:
             return GetStdoutQuiet(["xcrun", "--sdk", sdk, infoitem])
-        except GypError:
+        except (GypError, OSError):
             pass
 
     def _SdkRoot(self, configname):
@@ -1542,14 +1542,14 @@ def CLTVersion():
         try:
             output = GetStdout(["/usr/sbin/pkgutil", "--pkg-info", key])
             return re.search(regex, output).groupdict()["version"]
-        except GypError:
+        except (GypError, OSError):
             continue
 
     regex = re.compile(r"Command Line Tools for Xcode\s+(?P<version>\S+)")
     try:
         output = GetStdout(["/usr/sbin/softwareupdate", "--history"])
         return re.search(regex, output).groupdict()["version"]
-    except GypError:
+    except (GypError, OSError):
         return None
 
 


### PR DESCRIPTION
As titled, when trying to run the script in an environment that doesn't have any `xcodebuild` in the path, it crashes with a `FileNotFoundError` instead of falling back to the XCode Command Line Tools.