### PR TITLE
fix(build): Use SPDX license expression

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,14 +10,14 @@ authors = [
 ]
 description = "A fork of the GYP build system for use in the Node.js projects"
 readme = "README.md"
-license = { file="LICENSE" }
+license = "BSD-3-Clause"
+license-files = ["LICENSE"]
 requires-python = ">=3.9"
-dependencies = ["packaging>=24.0", "setuptools>=69.5.1"]
+dependencies = ["packaging>=24.0", "setuptools>=77.0.3"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Environment :: Console",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: BSD License",
     "Natural Language :: English",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
# ~Blocked by support for end-of-life Python 3.8~
* ~#339~ 

Fix build warnings:
```
[ ... ] /python3.13/site-packages/setuptools/dist.py:759: SetuptoolsDeprecationWarning:
  License classifiers are deprecated.
!!

        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: BSD License

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
  self._finalize_license_expression()
```

The SPDX license expression was found by reading the top of https://github.com/nodejs/gyp-next/blob/main/LICENSE and then looking up the correct value at https://spdx.org/licenses