### PR TITLE
fix: handle `None` case in xcode_emulation regexes

### DIFF
--- a/pylib/gyp/xcode_emulation.py
+++ b/pylib/gyp/xcode_emulation.py
@@ -1534,18 +1534,22 @@ def CLTVersion():
     FROM_XCODE_PKG_ID = "com.apple.pkg.DeveloperToolsCLI"
     MAVERICKS_PKG_ID = "com.apple.pkg.CLTools_Executables"
 
-    regex = re.compile("version: (?P<version>.+)")
+    regex = re.compile(r"version: (?P<version>.+)")
     for key in [MAVERICKS_PKG_ID, STANDALONE_PKG_ID, FROM_XCODE_PKG_ID]:
         try:
             output = GetStdout(["/usr/sbin/pkgutil", "--pkg-info", key])
-            return re.search(regex, output).groupdict()["version"]
+            m = re.search(regex, output)
+            if m:
+                return m.groupdict()["version"]
         except (GypError, OSError):
             continue
 
     regex = re.compile(r"Command Line Tools for Xcode\s+(?P<version>\S+)")
     try:
         output = GetStdout(["/usr/sbin/softwareupdate", "--history"])
-        return re.search(regex, output).groupdict()["version"]
+        m = re.search(regex, output)
+        if m:
+            return m.groupdict()["version"]
     except (GypError, OSError):
         return None
 


### PR DESCRIPTION
In the case where `softwareupdate --history` does not list any CLT update, the program crashes with an unhelpful error instead of trying the next fallback.