### PR TITLE
chore(ci): GitHub Actions: Test on macos-26 and Python 3.14 rc 2

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -16,6 +16,11 @@ jobs:
       matrix:
         os: [macos-13, macos-latest, ubuntu-latest] # , windows-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        include:
+          - os: macos-26
+            python-version: 3.x
+          - os: ubuntu-latest
+            python-version: 3.14
     steps:
       - uses: actions/checkout@v5
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
macOS 26 -- macOS Tahoe 9.15
* https://www.apple.com/os/macos
* https://github.com/actions/runner-images/releases

Python v3.14 -- October 7th
* https://www.python.org/download/pre-releases
* https://www.python.org/downloads/release/python-3140rc2