### PR TITLE
chore(ci): Test on Python 3.14 release candidate 3 on Linux and macOS

### DIFF
--- a/.github/workflows/node-gyp.yml
+++ b/.github/workflows/node-gyp.yml
@@ -9,19 +9,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ["22"]
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: ["3.9", "3.11", "3.13"]
+        python-version: ["3.10", "3.12", "3.14"]
+        exclude:
+          # Windows on Python 3.14 is blocked by nodejs/node#59983
+          - os: windows-latest
+            python-version: "3.14"
         include:
-          - node-version: "22"
-            os: macos-13  # macOS on Intel
+          - os: windows-latest  # Windows on Python 3.13 instead of 3.14
             python-version: "3.13"
-          - node-version: "22"
-            os: ubuntu-24.04-arm  # Ubuntu on ARM
-            python-version: "3.13"
-          - node-version: "22"
-            os: windows-11-arm  # Windows on ARM
-            python-version: "3.13"
+          - os: macos-15-intel  # macOS on Intel
+            python-version: "3.14"
+          - os: ubuntu-24.04-arm  # Ubuntu on ARM
+            python-version: "3.14"
+          - os: windows-11-arm  # Windows on ARM
+            python-version: "3.13"  # Windows on Python 3.13 instead of 3.14
     runs-on: ${{ matrix.os }}
     steps:
       - name: Clone gyp-next
@@ -35,7 +37,7 @@ jobs:
           path: node-gyp
       - uses: actions/setup-node@v5
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: "lts/*"
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -10,14 +10,20 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python: ["3.9", "3.11", "3.13"]
+        python-version: ["3.10", "3.12", "3.14"]
+        exclude:
+          # Windows on Python 3.14 is blocked by nodejs/node#59983
+          - os: windows-latest
+            python-version: "3.14"
         include:
-          - os: macos-13  # macOS on Intel
+          - os: windows-latest  # Windows on Python 3.13 instead of 3.14
             python-version: "3.13"
+          - os: macos-15-intel  # macOS on Intel
+            python-version: "3.14"
           - os: ubuntu-24.04-arm  # Ubuntu on ARM
-            python-version: "3.13"
+            python-version: "3.14"
           - os: windows-11-arm  # Windows on ARM
-            python-version: "3.13"
+            python-version: "3.13"  # Windows on Python 3.13 instead of 3.14
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -32,7 +38,7 @@ jobs:
           path: node
       - uses: actions/setup-python@v6
         with:
-          python-version: ${{ matrix.python }}
+          python-version: ${{ matrix.python-version }}
           allow-prereleases: true
       - name: Replace gyp in Node.js
         shell: bash

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -14,13 +14,11 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        os: [macos-13, macos-latest, ubuntu-latest] # , windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        os: [macos-15-intel, macos-latest, ubuntu-latest] # , windows-latest]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         include:
           - os: macos-26
             python-version: 3.x
-          - os: ubuntu-latest
-            python-version: 3.14
     steps:
       - uses: actions/checkout@v5
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
Python v3.14 -- October 7th
* https://www.python.org/download/pre-releases
* https://www.python.org/downloads/release/python-3140rc3

Node.js using Python 3.14 on Windows is blocked by:
* nodejs/node#59983

---
Also, upgrade from deprecated `macos-13` to `macos-15-intel`.

The currently available GitHub Actions macOS runners are:
| macOS Version | runner.arch |
|---------------|-------------|
| macos-13 | X64 |
| macos-14 | ARM64 |
| macos-15 | ARM64 |
| macos-15-intel | X64 |
| macos-26 | ARM64 |
| macos-latest | ARM64 |
* Let's prepare for actions/runner-images#13046