### PR TITLE
msvs.py: Use floor division when escaping command-line arguments

### DIFF
--- a/pylib/gyp/generator/msvs.py
+++ b/pylib/gyp/generator/msvs.py
@@ -857,7 +857,7 @@ def _EscapeCommandLineArgumentForMSBuild(s):
     """Escapes a Windows command-line argument for use by MSBuild."""
 
     def _Replace(match):
-        return (len(match.group(1)) / 2 * 4) * "\\" + '\\"'
+        return (len(match.group(1)) // 2 * 4) * "\\" + '\\"'
 
     # Escape all quotes so that they are interpreted literally.
     s = quote_replacer_regex2.sub(_Replace, s)


### PR DESCRIPTION
Fixes nodejs/node-gyp#3296
* nodejs/node-gyp#3296

% `python3.14`
```
>>> import re
>>> s = "TEST_STRING=\\\"TEST\\\""
>>> quote_replacer_regex2 = re.compile(r'(\\+)"')
...
...
... def _EscapeCommandLineArgumentForMSBuild(s):
...     """Escapes a Windows command-line argument for use by MSBuild."""
...
...     def _Replace(match):
...         return (len(match.group(1)) / 2 * 4) * "\\" + '\\"'
...
...     # Escape all quotes so that they are interpreted literally.
...     s = quote_replacer_regex2.sub(_Replace, s)
...     return s
...
>>> _EscapeCommandLineArgumentForMSBuild(s)
Traceback (most recent call last):
  File "<python-input-3>", line 1, in <module>
    _EscapeCommandLineArgumentForMSBuild(s)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^
  File "<python-input-1>", line 11, in _EscapeCommandLineArgumentForMSBuild
    s = quote_replacer_regex2.sub(_Replace, s)
  File "<python-input-1>", line 8, in _Replace
    return (len(match.group(1)) / 2 * 4) * "\\" + '\\"'
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
TypeError: can't multiply sequence by non-int of type 'float'

>>> Modify _Replace() to use floor division...
>>> _EscapeCommandLineArgumentForMSBuild(s)
'TEST_STRING=\\"TEST\\"'
```

@kuenzign


BEGIN_COMMIT_OVERRIDE
fix: use floor division when escaping command-line arguments (#338)
END_COMMIT_OVERRIDE