### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -8,10 +8,7 @@ on:
 
 jobs:
   Python_lint:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.14"]
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v6
       - name: Lint with ruff  # See pyproject.toml for settings
@@ -22,17 +19,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
-      max-parallel: 5
       matrix:
         os: [macos-15-intel, macos-latest, ubuntu-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         include:
           - os: macos-26
             python-version: 3.x
           - os: ubuntu-24.04-arm  # Ubuntu on ARM
-            python-version: "3.14"
+            python-version: 3.x
           - os: windows-11-arm  # Windows on ARM
-            python-version: "3.14"
+            python-version: 3.x
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}

--- a/pylib/packaging/metadata.py
+++ b/pylib/packaging/metadata.py
@@ -21,27 +21,10 @@ from typing import (
 from . import requirements, specifiers, utils, version as version_module
 
 T = typing.TypeVar("T")
-if sys.version_info[:2] >= (3, 8):  # pragma: no cover
-    from typing import Literal, TypedDict
-else:  # pragma: no cover
-    if typing.TYPE_CHECKING:
-        from typing_extensions import Literal, TypedDict
-    else:
-        try:
-            from typing_extensions import Literal, TypedDict
-        except ImportError:
-
-            class Literal:
-                def __init_subclass__(*_args, **_kwargs):
-                    pass
-
-            class TypedDict:
-                def __init_subclass__(*_args, **_kwargs):
-                    pass
-
+from typing import Literal, TypedDict
 
 try:
-    ExceptionGroup
+    ExceptionGroup  # Added in Python 3.11+
 except NameError:  # pragma: no cover
 
     class ExceptionGroup(Exception):  # noqa: N818
@@ -504,7 +487,7 @@ class _Validator(Generic[T]):
         self.raw_name = _RAW_TO_EMAIL_MAPPING[name]
 
     def __get__(self, instance: "Metadata", _owner: Type["Metadata"]) -> T:
-        # With Python 3.8, the caching can be replaced with functools.cached_property().
+        # With Python 3.8+, the caching can be replaced with functools.cached_property().
         # No need to check the cache as attribute lookup will resolve into the
         # instance's __dict__ before __get__ is called.
         cache = instance.__dict__

--- a/pylib/packaging/tags.py
+++ b/pylib/packaging/tags.py
@@ -127,10 +127,8 @@ def _normalize_string(string: str) -> str:
 def _abi3_applies(python_version: PythonVersion) -> bool:
     """
     Determine if the Python version supports abi3.
-
-    PEP 384 was first implemented in Python 3.2.
     """
-    return len(python_version) > 1 and tuple(python_version) >= (3, 2)
+    return len(python_version) > 1
 
 
 def _cpython_abis(py_version: PythonVersion, warn: bool = False) -> List[str]:
@@ -146,17 +144,7 @@ def _cpython_abis(py_version: PythonVersion, warn: bool = False) -> List[str]:
     has_ext = "_d.pyd" in EXTENSION_SUFFIXES
     if with_debug or (with_debug is None and (has_refcount or has_ext)):
         debug = "d"
-    if py_version < (3, 8):
-        with_pymalloc = _get_config_var("WITH_PYMALLOC", warn)
-        if with_pymalloc or with_pymalloc is None:
-            pymalloc = "m"
-        if py_version < (3, 3):
-            unicode_size = _get_config_var("Py_UNICODE_SIZE", warn)
-            if unicode_size == 4 or (
-                unicode_size is None and sys.maxunicode == 0x10FFFF
-            ):
-                ucs4 = "u"
-    elif debug:
+    if debug:
         # Debug builds can also load "normal" extension modules.
         # We can also assume no UCS-4 or pymalloc requirement.
         abis.append(f"cp{version}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 description = "A fork of the GYP build system for use in the Node.js projects"
 readme = "README.md"
 license = { file="LICENSE" }
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = ["packaging>=24.0", "setuptools>=69.5.1"]
 classifiers = [
     "Development Status :: 3 - Alpha",
@@ -21,10 +21,12 @@ classifiers = [
     "Natural Language :: English",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Both Python 3.8 and 3.9 are [end-of-life](https://devguide.python.org/versions), but we might want to continue to support Py3.9 until the [31 August 2026 EOL](https://wiki.debian.org/DebianReleases#Versions_of_Debian_stable) of Debian 11 Bullseye Standard Support.