### PR TITLE
Fix add dict.items() in dictionary iteration

### DIFF
--- a/pylib/gyp/generator/ninja_test.py
+++ b/pylib/gyp/generator/ninja_test.py
@@ -39,7 +39,7 @@ class TestPrefixesAndSuffixes(unittest.TestCase):
             "executable": ".exe",
             "shared_library": ".dll",
             "static_library": ".lib",
-        }:
+        }.items():
             self.assertTrue(writer.ComputeOutputFileName(spec, key).endswith(ext))
 
     def test_BinaryNamesLinux(self):


### PR DESCRIPTION
Fix for Windows test blocking:
* nodejs/node-gyp#3295

BEGIN_COMMIT_OVERRIDE
fix: add dict.items() in dictionary iteration (#341)
END_COMMIT_OVERRIDE