### PR TITLE
ci: declare contents:read on node-gyp integration workflow

### DIFF
--- a/.github/workflows/node-gyp.yml
+++ b/.github/workflows/node-gyp.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   node-gyp-integration:
     strategy:


### PR DESCRIPTION
Declares `permissions: contents: read` at the top of `.github/workflows/node-gyp.yml`. The integration job checks out the repo, sets up Node and Python across a few versions, installs `node-gyp`, then drives a small build matrix. No part of that path needs anything beyond read on the contents.

CVE-2025-30066 (the March 2025 `tj-actions/changed-files` supply-chain attack) is the reason this kind of cap matters in practice: a compromised third-party action can read `GITHUB_TOKEN` out of workflow logs, and the leaked token retains whatever scope was issued. Adding an in-file `contents: read` block bounds the runtime authority for this workflow regardless of what the repo or org default happens to be set to today, and it gives drift protection if that default ever changes. OpenSSF Scorecard's Token-Permissions check looks for the explicit per-workflow block too.

YAML validated locally via `yaml.safe_load`.
