### PR TITLE
fix(ci): update ruff github action to v4.0.0

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Lint with ruff  # See pyproject.toml for settings
-        uses: astral-sh/ruff-action@v3
+        uses: astral-sh/ruff-action@v4.0.0
       - run: ruff format --check --diff
       - uses: wagoid/commitlint-github-action@v6
 


### PR DESCRIPTION
Like:
* nodejs/node-gyp#3324

Dependabot seems to have trouble switching to ___immutable releases___ like:
* https://github.com/astral-sh/ruff-action/releases/tag/v4.0.0