### PR TITLE
feat: support GNU/Hurd

### DIFF
--- a/pylib/gyp/common.py
+++ b/pylib/gyp/common.py
@@ -506,6 +506,8 @@ def GetFlavorByPlatform():
         return "zos"
     if sys.platform == "os400":
         return "os400"
+    if re.fullmatch("gnu\\d+", sys.platform):
+        return "hurd"
 
     return "linux"
 

--- a/pylib/gyp/common_test.py
+++ b/pylib/gyp/common_test.py
@@ -76,6 +76,7 @@ class TestGetFlavor(unittest.TestCase):
         self.assertFlavor("linux", "linux2", {})
         self.assertFlavor("linux", "linux3", {})
         self.assertFlavor("linux", "linux", {})
+        self.assertFlavor("hurd", "gnu0", {})
 
     def test_param(self):
         self.assertFlavor("foobar", "linux2", {"flavor": "foobar"})

--- a/pylib/gyp/generator/make.py
+++ b/pylib/gyp/generator/make.py
@@ -1888,7 +1888,7 @@ $(obj).$(TOOLSET)/$(TARGET)/%%.o: $(obj)/%%%s FORCE_DO_CMD
                 self.flavor not in ("mac", "openbsd", "netbsd", "win")
                 and not self.is_standalone_static_library
             ):
-                if self.flavor in ("linux", "android", "openharmony"):
+                if self.flavor in ("linux", "android", "openharmony", "hurd"):
                     self.WriteMakeRule(
                         [self.output_binary],
                         link_deps,
@@ -1902,7 +1902,7 @@ $(obj).$(TOOLSET)/$(TARGET)/%%.o: $(obj)/%%%s FORCE_DO_CMD
                         part_of_all,
                         postbuilds=postbuilds,
                     )
-            elif self.flavor in ("linux", "android", "openharmony"):
+            elif self.flavor in ("linux", "android", "openharmony", "hurd"):
                 self.WriteMakeRule(
                     [self.output_binary],
                     link_deps,

--- a/test_gyp.py
+++ b/test_gyp.py
@@ -128,6 +128,7 @@ def main(argv=None):
             # https://bugs.chromium.org/p/gyp/issues/detail?id=530
             # 'darwin':   ['make', 'ninja', 'xcode', 'xcode-ninja'],
             "darwin": ["make", "ninja", "xcode"],
+            "gnu0": ["make", "ninja"],
         }[sys.platform]
 
     gyp_options = []


### PR DESCRIPTION
Recognize & handle GNU/Hurd as separate platform, so `OS` == `hurd`.

Follow the Linux behaviour in a couple of places, as the underlying GNU toolchain is mostly the same.