### PR TITLE
fix: write pch cflags as a list instead of a map object

### DIFF
--- a/pylib/gyp/msvs_emulation.py
+++ b/pylib/gyp/msvs_emulation.py
@@ -1057,13 +1057,18 @@ class PrecompiledHeader:
             pch_output = ["/Yc" + self._PchHeader()]
             if command == "cxx":
                 return (
-                    [("cflags_cc", map(expand_special, cflags_cc + pch_output))],
+                    [
+                        (
+                            "cflags_cc",
+                            [expand_special(x) for x in cflags_cc + pch_output],
+                        )
+                    ],
                     self.output_obj,
                     [],
                 )
             elif command == "cc":
                 return (
-                    [("cflags_c", map(expand_special, cflags_c + pch_output))],
+                    [("cflags_c", [expand_special(x) for x in cflags_c + pch_output])],
                     self.output_obj,
                     [],
                 )

--- a/test/fixtures/pch.cc
+++ b/test/fixtures/pch.cc
@@ -1,0 +1,1 @@
+#include "pch.h"

--- a/test/fixtures/pch.gyp
+++ b/test/fixtures/pch.gyp
@@ -1,0 +1,13 @@
+{
+  'targets': [
+    {
+      'target_name': 'pch',
+      'type': 'executable',
+      'sources': [
+        'pch.cc',
+      ],
+      'msvs_precompiled_header': 'pch.h',
+      'msvs_precompiled_source': 'pch.cc',
+    },
+  ]
+}

--- a/test/fixtures/pch.h
+++ b/test/fixtures/pch.h
@@ -1,0 +1,1 @@
+#pragma once

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -11,7 +11,8 @@ import unittest
 import gyp
 
 fixture_dir = os.path.join(os.path.dirname(__file__), "fixtures")
-gyp_file = os.path.join(os.path.dirname(__file__), "fixtures/integration.gyp")
+gyp_file = os.path.join(fixture_dir, "integration.gyp")
+pch_gyp_file = os.path.join(fixture_dir, "pch.gyp")
 
 if sys.platform == "win32":
     sysname = sys.platform
@@ -91,3 +92,16 @@ class TestGypWindows(unittest.TestCase):
 
         assert_file(self, "test.vcproj", "msvs/test.vcproj")
         assert_file(self, "integration.sln", "msvs/integration.sln")
+
+    def test_ninja_precompiled_header(self) -> None:
+        try:
+            rc = gyp.main(["-f", "ninja", "--depth", fixture_dir, pch_gyp_file])
+        except ValueError as exc:
+            self.skipTest(str(exc))
+        assert rc == 0
+
+        with open(os.path.join(fixture_dir, "out/Default/obj/pch.ninja")) as in_file:
+            ninja_file = in_file.read()
+
+        assert "map object at" not in ninja_file
+        assert "/Ycpch.h" in ninja_file


### PR DESCRIPTION
## Problem

`GetFlagsModifications` returned `map` objects for `cflags_c`/`cflags_cc`.

The `/Yc` flag never reached `cl.exe`, so precompiled headers were broken for every ninja build on Windows.

## Fix

Replace both `map()` calls with list comprehensions.

## Test

`test_ninja_precompiled_header` runs the ninja generator over a new PCH fixture and asserts the flags are written out instead of a `map` object.

Refs: https://github.com/nodejs/node/issues/57633