### PR TITLE
fix(ci): enable Python 3.15 release candidate on Windows

### DIFF
--- a/.github/workflows/node-gyp.yml
+++ b/.github/workflows/node-gyp.yml
@@ -23,9 +23,6 @@ jobs:
             python-version: 3.x
           - os: windows-2025-vs2026  # Windows with Visual Studio 2026
             python-version: 3.x
-        exclude:  # Reenable after Python 3.15 beta 1
-          - os: windows-latest
-            python-version: "3.15"
     runs-on: ${{ matrix.os }}
     steps:
       - name: Clone gyp-next


### PR DESCRIPTION
Re-enable Windows latest configuration for Python 3.15 which is scheduled to be production released on Oct. 1st.

The actions/setup-python@7 job ends with:
> Successfully set up CPython (3.15.0-rc.1)

We want to understand why CPython 3.15.0-rc.1 is failing only on Windows so we can report the error to the CPython development team before CPython 3.15 is released.

@ethanstoner