### PR TITLE
fix(ci): test on npm@12

### DIFF
--- a/.github/workflows/node-gyp.yml
+++ b/.github/workflows/node-gyp.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: ["3.10", "3.12", "3.14", "3.15"]
+        python-version: ["3.11", "3.13", "3.15"]
         include:
           - os: macos-26-intel  # macOS on Intel
             python-version: 3.x
@@ -51,6 +51,7 @@ jobs:
           pip uninstall -y gyp-next
       - name: Install Node.js dependencies
         run: |
+          npm install --global npm@12
           cd node-gyp
           npm install --no-progress
       - name: Replace gyp in node-gyp
@@ -62,10 +63,10 @@ jobs:
         if: runner.os != 'Windows'
         run: |
           cd node-gyp
-          npm test --python="${pythonLocation}/python"
+          npm test
       - name: Run tests (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
           cd node-gyp
-          npm run test --python="${env:pythonLocation}\\python.exe"
+          npm run test

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: ["3.10", "3.12", "3.14", "3.15"]
+        python-version: ["3.11", "3.13", "3.15"]
         include:
           - os: macos-26-intel  # macOS on Intel
             python-version: 3.x

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]
+        python-version: ["3.11", "3.12", "3.13", "3.14", "3.15"]
         include:
           - os: macos-26-intel  # macOS on Intel
             python-version: 3.x

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ When used as a command line utility, __gyp-next__ can also be installed with [pi
 * `uv tool install gyp-next`
 ```
 Installing to a new venv 'gyp-next'
-  installed package gyp-next 0.13.0, installed using Python 3.10.6
+  installed package gyp-next 0.13.0, installed using Python 3.14.7
   These apps are now globally available
     - gyp
 done! ✨ 🌟 ✨


### PR DESCRIPTION
Updated the Node.js workflow to use npm 12 globally and drop --python from the npm test command.

On October 1st, Python 3.15 will be released, and Python 3.10 will reach EOL.